### PR TITLE
fix: responsive canvas scaling for mobile viewports

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -436,6 +436,42 @@ tbody tr.highlight-self {
   text-shadow: 0 0 6px var(--neon-cyan);
 }
 
+/* ---------- Game Canvas Responsive ---------- */
+canvas {
+  max-width: 100%;
+  height: auto;
+}
+
+.game-main {
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.game-main h1,
+.game-main h2 {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
+  text-align: center;
+}
+
+#overlay h2 {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+#overlay p {
+  max-width: 90%;
+  word-wrap: break-word;
+}
+
+#legend,
+#item-legend {
+  max-width: 100%;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 768px) {
   .hero h1 { font-size: 1.2rem; }
@@ -444,4 +480,8 @@ tbody tr.highlight-self {
   .navbar-links { gap: 12px; }
   .navbar-links a { font-size: 0.5rem; }
   .card-grid { grid-template-columns: 1fr; }
+
+  .game-layout { padding: 12px 8px; }
+  .game-main h1 { font-size: 1.1rem; letter-spacing: 0.05em; }
+  #hud { font-size: 0.8rem; gap: 0.8rem; flex-wrap: wrap; justify-content: center; }
 }

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -18,6 +18,8 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      max-width: 100%;
+      overflow: hidden;
     }
     .game-main h1 {
       color: #FFD700;
@@ -25,6 +27,9 @@
       letter-spacing: 0.15em;
       margin-bottom: 6px;
       text-shadow: 0 0 10px #FFD700;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
     }
     #hud {
       display: flex;
@@ -32,13 +37,17 @@
       margin-bottom: 8px;
       font-size: 1rem;
       color: #fff;
+      flex-wrap: wrap;
+      justify-content: center;
     }
     #hud span { color: #FFD700; }
-    #canvas-wrap { position: relative; }
+    #canvas-wrap { position: relative; max-width: 100%; }
     canvas {
       display: block;
       border: 2px solid #1a1aff;
       box-shadow: 0 0 20px #1a1aff88;
+      max-width: 100%;
+      height: auto;
     }
     #overlay {
       position: absolute;
@@ -50,7 +59,7 @@
       justify-content: center;
       gap: 14px;
     }
-    #overlay h2 { font-size: 2rem; color: #FFD700; font-family: var(--font-pixel); }
+    #overlay h2 { font-size: 2rem; color: #FFD700; font-family: var(--font-pixel); word-break: break-word; overflow-wrap: break-word; text-align: center; max-width: 90%; }
     #overlay p  { font-size: 1rem; color: #ccc; text-align: center; max-width: 340px; }
     #overlay button {
       background: #1a1aff;
@@ -70,6 +79,9 @@
       margin-top: 6px;
       font-size: 0.78rem;
       color: #aaa;
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 100%;
     }
     #item-legend span { color: #fff; }
 

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -19,6 +19,8 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      max-width: 100%;
+      overflow: hidden;
     }
     .game-main h1 {
       font-size: 1.5rem;
@@ -26,6 +28,9 @@
       text-shadow: 0 0 10px #0ff, 0 0 20px #0ff;
       margin-bottom: 0.5rem;
       color: #0ff;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
     }
     #hud {
       display: flex;
@@ -34,12 +39,16 @@
       margin-bottom: 0.5rem;
       text-shadow: 0 0 6px #0ff;
       color: #0ff;
+      flex-wrap: wrap;
+      justify-content: center;
     }
-    #canvas-wrapper { position: relative; }
+    #canvas-wrapper { position: relative; max-width: 100%; }
     canvas {
       display: block;
       border: 2px solid #0ff;
       box-shadow: 0 0 20px #0ff, 0 0 40px #0080ff;
+      max-width: 100%;
+      height: auto;
     }
     #overlay {
       position: absolute;
@@ -57,6 +66,10 @@
       text-shadow: 0 0 10px #0ff;
       letter-spacing: 0.2em;
       font-family: var(--font-pixel);
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+      max-width: 90%;
     }
     #overlay p { font-size: 1.1rem; opacity: 0.85; }
     #overlay button {
@@ -78,6 +91,9 @@
       font-size: 0.8rem;
       margin-top: 0.5rem;
       opacity: 0.7;
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 100%;
     }
     .legend-item { display: flex; align-items: center; gap: 0.4rem; }
     .legend-dot {

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -19,6 +19,8 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      max-width: 100%;
+      overflow: hidden;
     }
     .game-main h1 {
       font-size: 1.4rem;
@@ -26,6 +28,9 @@
       text-shadow: 0 0 10px #f0f, 0 0 20px #f0f;
       margin-bottom: 0.4rem;
       color: #f0f;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
     }
     #hud {
       display: flex;
@@ -37,11 +42,13 @@
       flex-wrap: wrap;
       justify-content: center;
     }
-    #canvas-wrapper { position: relative; }
+    #canvas-wrapper { position: relative; max-width: 100%; }
     canvas {
       display: block;
       border: 2px solid #f0f;
       box-shadow: 0 0 20px #f0f, 0 0 40px #8000ff;
+      max-width: 100%;
+      height: auto;
     }
     #overlay {
       position: absolute;
@@ -59,6 +66,10 @@
       text-shadow: 0 0 10px #f0f;
       letter-spacing: 0.2em;
       font-family: var(--font-pixel);
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+      max-width: 90%;
     }
     #overlay p {
       font-size: 0.95rem;


### PR DESCRIPTION
## Summary

- Canvas elements now scale to fit narrow viewports (375px) via CSS `max-width: 100%; height: auto;` — no game logic changes
- All three games (Pac-Maze Rush, Neon Growth, Asteroid Defense Surge) have responsive canvas wrappers, titles, HUDs, and legends
- Text elements (h1, overlay h2, instructions) use `word-break: break-word; overflow-wrap: break-word` to prevent clipping
- Flex containers (HUD, legends) wrap on narrow screens with `flex-wrap: wrap; justify-content: center`
- Mobile media query adds tighter padding and smaller font sizes at <=768px

## Approach

CSS-only scaling: the canvas internal resolution stays unchanged (420x420 for pacmaze, 600x600 for snake, 700x520 for asteroids), so game coordinate systems and collision logic are untouched. Only the CSS display size adapts to the viewport.

Closes #21

## Test plan

- [x] `npm test` — all 188 tests pass, 0 failures
- [ ] Visual QA: open each game at 375px viewport width, verify canvas fits, titles don't clip, START button visible
- [ ] Verify games still play correctly after canvas scales down (click/touch targets, game logic unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)