### PR TITLE
fix: refresh leaderboard after score submission, show feedback on failure

### DIFF
--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -488,7 +488,21 @@
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ score }),
-    }).catch(() => {});
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          showOverlayMessage('Log in to save your score');
+        } else if (res.status === 429) {
+          showOverlayMessage('Score already submitted recently');
+        } else if (res.ok) {
+          const data = await res.json();
+          showOverlayMessage(`Saved! You ranked #${data.rank}`);
+          if (window.loadMiniLeaderboard) window.loadMiniLeaderboard();
+        } else {
+          showOverlayMessage('Score could not be saved');
+        }
+      })
+      .catch(() => showOverlayMessage('Score could not be saved'));
   }
 
   // -- Overlay helpers ------------------------------------------------------------
@@ -504,6 +518,19 @@
       overlay.style.display = 'none';
       btnAction();
     });
+  }
+
+  function showOverlayMessage(msg) {
+    const overlay = document.getElementById('overlay');
+    const existing = overlay.querySelector('.overlay-status');
+    if (existing) existing.remove();
+    const p = document.createElement('p');
+    p.className = 'overlay-status';
+    p.style.fontSize = '0.85rem';
+    p.style.color = '#FFD700';
+    p.style.marginTop = '4px';
+    p.textContent = msg;
+    overlay.appendChild(p);
   }
 
   function hideOverlay() {

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -199,6 +199,7 @@
     }
 
     loadMiniLeaderboard();
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
   </script>
   <script src="game.js"></script>
 </body>

--- a/public/games/snake/game.js
+++ b/public/games/snake/game.js
@@ -298,15 +298,42 @@ class NeonGrowth {
       this.highScoreEl.textContent = this.highScore;
     }
 
-    // Submit score (fire-and-forget)
+    // Submit score with feedback
     fetch('/api/scores/neon-growth', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ score: this.score }),
-    }).catch(() => {});
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          this._showOverlayMessage('Log in to save your score');
+        } else if (res.status === 429) {
+          this._showOverlayMessage('Score already submitted recently');
+        } else if (res.ok) {
+          const data = await res.json();
+          this._showOverlayMessage(`Saved! You ranked #${data.rank}`);
+          if (window.loadMiniLeaderboard) window.loadMiniLeaderboard();
+        } else {
+          this._showOverlayMessage('Score could not be saved');
+        }
+      })
+      .catch(() => this._showOverlayMessage('Score could not be saved'));
 
     this._showGameOver();
+  }
+
+  _showOverlayMessage(msg) {
+    const ov = this.overlay;
+    const existing = ov.querySelector('.overlay-status');
+    if (existing) existing.remove();
+    const p = document.createElement('p');
+    p.className = 'overlay-status';
+    p.style.fontSize = '0.85rem';
+    p.style.color = '#0ff';
+    p.style.marginTop = '4px';
+    p.textContent = msg;
+    ov.appendChild(p);
   }
 
   _showGameOver() {

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -211,6 +211,7 @@
     }
 
     loadMiniLeaderboard();
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
   </script>
   <script src="game.js" type="module"></script>
 </body>

--- a/public/games/space-invaders/game.js
+++ b/public/games/space-invaders/game.js
@@ -796,15 +796,42 @@ class AsteroidDefenseRenderer {
       localStorage.setItem('asteroidDefenseHighScore', String(this.highScore));
     }
 
-    // Submit score
+    // Submit score with feedback
     fetch('/api/scores/space-invaders', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify({ score: state.score }),
-    }).catch(() => {});
+    })
+      .then(async (res) => {
+        if (res.status === 401) {
+          this._showOverlayMessage('Log in to save your score');
+        } else if (res.status === 429) {
+          this._showOverlayMessage('Score already submitted recently');
+        } else if (res.ok) {
+          const data = await res.json();
+          this._showOverlayMessage(`Saved! You ranked #${data.rank}`);
+          if (window.loadMiniLeaderboard) window.loadMiniLeaderboard();
+        } else {
+          this._showOverlayMessage('Score could not be saved');
+        }
+      })
+      .catch(() => this._showOverlayMessage('Score could not be saved'));
 
     this._showGameOver(state);
+  }
+
+  _showOverlayMessage(msg) {
+    const ov = this.overlay;
+    const existing = ov.querySelector('.overlay-status');
+    if (existing) existing.remove();
+    const p = document.createElement('p');
+    p.className = 'overlay-status';
+    p.style.fontSize = '0.85rem';
+    p.style.color = '#f0f';
+    p.style.marginTop = '4px';
+    p.textContent = msg;
+    ov.appendChild(p);
   }
 
   _showGameOver(state) {

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -230,6 +230,7 @@
     }
 
     loadMiniLeaderboard();
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
   </script>
   <script src="game.js"></script>
 </body>

--- a/src/__tests__/neon-growth.test.js
+++ b/src/__tests__/neon-growth.test.js
@@ -44,8 +44,9 @@ const fn = new Function(
 );
 
 const makeDomEl = () => ({
-  textContent: '', style: {}, innerHTML: '',
+  textContent: '', style: {}, innerHTML: '', className: '',
   appendChild: () => {}, addEventListener: () => {},
+  querySelector: () => null, remove: () => {},
 });
 
 fn(
@@ -75,7 +76,7 @@ function buildGame() {
     lineWidth: 0, globalAlpha: 1,
   };
   const mockCanvas = { getContext: () => mockCtx, width: 0, height: 0 };
-  const mockOverlay = { innerHTML: '', style: {}, appendChild: () => {} };
+  const mockOverlay = { innerHTML: '', style: {}, appendChild: () => {}, querySelector: () => null };
   const mockEl = { textContent: '' };
 
   const game = new NeonGrowth(mockCanvas, mockOverlay, mockEl, mockEl, mockEl);


### PR DESCRIPTION
Fixes #23

## Summary
- **Expose `loadMiniLeaderboard()`** to `window` in all 3 game HTML files (pacmaze, snake, space-invaders) so game.js can trigger a refresh after successful score submission
- **Replace silent `.catch(() => {})`** in all 3 game.js files with explicit error handling that shows status messages in the game-over overlay:
  - 401 → "Log in to save your score"
  - 429 → "Score already submitted recently"
  - 200 → "Saved! You ranked #N" + refreshes mini-leaderboard
  - Other/network errors → "Score could not be saved"
- **Add `showOverlayMessage()` helper** to each game that appends a styled `<p>` status line to the game-over overlay
- **Fix test mock** in `neon-growth.test.js` — add `querySelector` to mock overlay/DOM elements so the new async error handler doesn't cause unhandledRejection

## Test plan
- [x] `npm test` — 188/188 pass, 0 fail
- [ ] Manual: play pacmaze → game over → verify status message appears and leaderboard refreshes
- [ ] Manual: play snake → game over → same
- [ ] Manual: play space-invaders → game over → same
- [ ] Manual: log out → game over → verify "Log in to save your score" message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved score submission feedback across all games with status-specific messages: login prompts for unauthenticated users, rate-limit notifications, and save confirmations displaying your rank.
  * Fixed leaderboard to refresh automatically after successful score submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->