### PR TITLE
fix: visual QA fixes — touch controls, 404 page, mobile leaderboard (#34-#37)

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>404 — Retro Arcade</title>
+  <link rel="stylesheet" href="/css/main.css" />
+</head>
+<body>
+  <nav class="navbar">
+    <a href="/" class="navbar-brand">RETRO ARCADE</a>
+    <div class="navbar-links">
+      <a href="/leaderboard.html">Leaderboard</a>
+    </div>
+  </nav>
+
+  <div class="container" style="text-align:center;padding-top:80px;">
+    <h1 style="font-family:var(--font-pixel);font-size:3rem;color:var(--neon-pink);text-shadow:0 0 20px var(--neon-pink);margin-bottom:20px;">404</h1>
+    <h2 style="font-family:var(--font-pixel);font-size:0.8rem;color:var(--neon-cyan);text-shadow:0 0 10px var(--neon-cyan);margin-bottom:30px;">GAME OVER — PAGE NOT FOUND</h2>
+    <p style="color:var(--text);margin-bottom:40px;">The page you're looking for doesn't exist or has been moved.</p>
+    <a href="/" class="btn">INSERT COIN TO CONTINUE</a>
+  </div>
+
+  <footer class="footer">
+    RETRO ARCADE &copy; 2026 &mdash; Insert Coin to Continue
+  </footer>
+</body>
+</html>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -286,6 +286,7 @@ a:hover {
 
 table {
   width: 100%;
+  min-width: 520px;
   border-collapse: collapse;
   font-size: 0.85rem;
 }
@@ -472,6 +473,94 @@ canvas {
   justify-content: center;
 }
 
+/* ---------- Mobile Touch Controls (d-pad) ---------- */
+.touch-controls {
+  display: none;
+  margin-top: 12px;
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+.dpad {
+  display: grid;
+  grid-template-columns: 56px 56px 56px;
+  grid-template-rows: 56px 56px 56px;
+  gap: 4px;
+  justify-content: center;
+}
+
+.dpad-btn {
+  width: 56px;
+  height: 56px;
+  border: 2px solid var(--neon-cyan);
+  background: rgba(0, 255, 255, 0.08);
+  color: var(--neon-cyan);
+  font-size: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.1s;
+}
+
+.dpad-btn:active {
+  background: rgba(0, 255, 255, 0.3);
+  box-shadow: 0 0 12px var(--neon-cyan);
+}
+
+.dpad-btn--blank {
+  border: none;
+  background: transparent;
+}
+
+/* Space-invaders horizontal controls */
+.touch-controls-row {
+  display: flex;
+  gap: 16px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 12px;
+}
+
+.touch-btn-fire {
+  width: 72px;
+  height: 72px;
+  border: 2px solid var(--neon-pink);
+  background: rgba(255, 0, 255, 0.08);
+  color: var(--neon-pink);
+  font-family: var(--font-pixel);
+  font-size: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.1s;
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+.touch-btn-fire:active {
+  background: rgba(255, 0, 255, 0.3);
+  box-shadow: 0 0 12px var(--neon-pink);
+}
+
+.touch-hint {
+  font-family: var(--font-pixel);
+  font-size: 0.4rem;
+  color: #555;
+  text-align: center;
+  margin-top: 6px;
+}
+
+@media (pointer: coarse) {
+  .touch-controls { display: block; }
+}
+
 /* ---------- Responsive ---------- */
 @media (max-width: 768px) {
   .hero h1 { font-size: 1.2rem; }
@@ -484,4 +573,6 @@ canvas {
   .game-layout { padding: 12px 8px; }
   .game-main h1 { font-size: 1.1rem; letter-spacing: 0.05em; }
   #hud { font-size: 0.8rem; gap: 0.8rem; flex-wrap: wrap; justify-content: center; }
+
+  .touch-controls { display: block; }
 }

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -150,7 +150,7 @@
         <canvas id="game-canvas"></canvas>
         <div id="overlay">
           <h2>PAC-MAZE RUSH</h2>
-          <p>Arrow keys or WASD to move. Eat all dots to advance!<br>Power pellets let you eat ghosts!</p>
+          <p>Arrow keys, WASD, or swipe to move. Eat all dots to advance!<br>Power pellets let you eat ghosts!</p>
           <div id="item-legend">
             <div>&#10052; Freeze ghosts 5s</div>
             <div>&#11088; Score Bomb 2x 10s</div>
@@ -158,6 +158,20 @@
           </div>
           <button id="start-btn">START GAME</button>
         </div>
+      </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="dpad">
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowUp">&#9650;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowLeft">&#9664;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowRight">&#9654;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowDown">&#9660;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+        </div>
+        <div class="touch-hint">SWIPE OR TAP TO MOVE</div>
       </div>
     </div>
 
@@ -171,6 +185,16 @@
 
   <script src="/js/api.js"></script>
   <script>
+    // D-pad touch controls
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      const fire = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', fire, { passive: false });
+      btn.addEventListener('mousedown', fire);
+    });
+
     document.addEventListener('DOMContentLoaded', () => {
       const logoutBtn = document.getElementById('nav-logout-btn');
       if (logoutBtn) {

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -166,7 +166,7 @@
         <canvas id="canvas" width="620" height="620"></canvas>
         <div id="overlay">
           <h2>NEON GROWTH</h2>
-          <p>Arrow keys or WASD to move</p>
+          <p>Arrow keys, WASD, or swipe to move</p>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -174,6 +174,20 @@
         <div class="legend-item"><div class="legend-dot" style="background:#ffd700;box-shadow:0 0 4px #ffd700;"></div> Gold Apple +50pts (5 seg)</div>
         <div class="legend-item"><div class="legend-dot" style="background:#c0c0c0;box-shadow:0 0 4px #c0c0c0;border-radius:50%"></div> Silver Circle +25pts (2 seg, speed)</div>
         <div class="legend-item"><div class="legend-dot" style="background:#00cfff;box-shadow:0 0 4px #00cfff;"></div> Diamond +200pts (10 seg)</div>
+      </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="dpad">
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowUp">&#9650;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowLeft">&#9664;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowRight">&#9654;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+          <button class="dpad-btn" data-key="ArrowDown">&#9660;</button>
+          <div class="dpad-btn dpad-btn--blank"></div>
+        </div>
+        <div class="touch-hint">SWIPE OR TAP TO MOVE</div>
       </div>
     </div>
 
@@ -187,6 +201,16 @@
 
   <script src="/js/api.js"></script>
   <script>
+    // D-pad touch controls
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      const fire = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', fire, { passive: false });
+      btn.addEventListener('mousedown', fire);
+    });
+
     document.addEventListener('DOMContentLoaded', () => {
       const logoutBtn = document.getElementById('nav-logout-btn');
       if (logoutBtn) {

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -174,8 +174,8 @@
         <div id="overlay">
           <h2>ASTEROID DEFENSE SURGE</h2>
           <p>
-            Arrow keys / WASD — Move<br>
-            Space — Shoot (hold for Charge/Laser)<br>
+            Arrow keys / WASD / Touch — Move<br>
+            Space / Tap — Shoot (hold for Charge/Laser)<br>
             Destroy orbiters to collect weapon upgrades
           </p>
           <button id="start-btn">START GAME</button>
@@ -189,6 +189,14 @@
         <div class="legend-item"><div class="legend-dot" style="background:#f0f;"></div> Missile</div>
         <div class="legend-item"><div class="legend-dot" style="background:#fff;box-shadow:0 0 4px #fff;border-radius:50%"></div> Shield+</div>
       </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="touch-controls-row">
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
+          <button class="touch-btn-fire" id="fire-btn">FIRE</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+        </div>
+        <div class="touch-hint">DRAG TO MOVE &bull; TAP TO FIRE</div>
+      </div>
     </div>
 
     <div class="game-leaderboard">
@@ -201,6 +209,43 @@
 
   <script src="/js/api.js"></script>
   <script>
+    // Touch controls — movement buttons
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      let interval = null;
+      const startMove = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        interval = setInterval(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        }, 80);
+      };
+      const stopMove = (e) => {
+        e.preventDefault();
+        clearInterval(interval);
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', startMove, { passive: false });
+      btn.addEventListener('touchend', stopMove, { passive: false });
+      btn.addEventListener('touchcancel', stopMove, { passive: false });
+    });
+
+    // Fire button — hold to charge, release to fire
+    const fireBtn = document.getElementById('fire-btn');
+    if (fireBtn) {
+      fireBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+      fireBtn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+      fireBtn.addEventListener('touchcancel', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const logoutBtn = document.getElementById('nav-logout-btn');
       if (logoutBtn) {

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { fileURLToPath } from 'node:url';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import Fastify from 'fastify';
 import fastifyJwt from '@fastify/jwt';
@@ -45,6 +46,15 @@ await app.register(leaderboardRoutes, { prefix: '/api/leaderboard' });
 
 // Health check
 app.get('/api/health', async () => ({ ok: true }));
+
+// Custom 404 handler — serve styled page for non-API routes
+const notFoundHtml = readFileSync(path.join(__dirname, '..', 'public', '404.html'), 'utf8');
+app.setNotFoundHandler((request, reply) => {
+  if (request.url === '/api' || request.url.startsWith('/api/')) {
+    return reply.code(404).send({ error: 'Not Found', statusCode: 404 });
+  }
+  return reply.code(404).type('text/html').send(notFoundHtml);
+});
 
 // Start
 const PORT = Number(process.env.PORT ?? 3000);


### PR DESCRIPTION
## Summary

Fixes 4 visual QA findings from the E2E smoke suite:

### Critical
- **#34 Mobile touch controls**: Added visible d-pad overlay for Pac-Maze and Neon Growth (4-directional), and left/right + fire buttons for Asteroid Defense. Controls dispatch keyboard events to existing game handlers. Updated overlay instructions to mention swipe/touch. CSS shows controls on touch devices and mobile viewports.

### Major
- **#35 Date 1970 visual**: Root cause already fixed in PR #38 (`submitted_at * 1000`). This issue is auto-closed by this PR.
- **#36 404 page**: Added styled `404.html` matching retro arcade theme. Custom Fastify `setNotFoundHandler` serves HTML for page requests, JSON for `/api` and `/api/*` routes.
- **#37 Mobile leaderboard**: Added `min-width: 520px` to tables, triggering horizontal scroll via existing `overflow-x: auto` on `.table-wrap`.

### Codex Review
- Fixed Major: `/api` (no trailing slash) now correctly returns JSON 404
- Minor: non-page asset 404s return HTML — acceptable for a game site
- D-pad controls dispatch correct key values matching game listeners
- No XSS introduced — all new markup is static

### Test Evidence
All 188 tests pass: `JWT_SECRET=test-secret CORS_ORIGIN=http://localhost:3000 DB_PATH=:memory: npm test`

Closes #34, #35, #36, #37