### PR TITLE
fix: leaderboard empty on load + rate limiter too aggressive (#41, #42)

### DIFF
--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -195,18 +195,9 @@
       btn.addEventListener('mousedown', fire);
     });
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const logoutBtn = document.getElementById('nav-logout-btn');
-      if (logoutBtn) {
-        logoutBtn.addEventListener('click', (e) => {
-          e.preventDefault();
-          api.logout();
-        });
-      }
-    });
-
     async function loadMiniLeaderboard() {
       const list = document.getElementById('lb-list');
+      if (!list) return;
       try {
         const res = await api.get('/api/scores/pacmaze');
         if (!res || !res.ok) throw new Error('fetch failed');
@@ -239,9 +230,18 @@
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }
-
-    loadMiniLeaderboard();
     window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
   </script>
   <script src="game.js"></script>
 </body>

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -211,18 +211,9 @@
       btn.addEventListener('mousedown', fire);
     });
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const logoutBtn = document.getElementById('nav-logout-btn');
-      if (logoutBtn) {
-        logoutBtn.addEventListener('click', (e) => {
-          e.preventDefault();
-          api.logout();
-        });
-      }
-    });
-
     async function loadMiniLeaderboard() {
       const list = document.getElementById('lb-list');
+      if (!list) return;
       try {
         const res = await api.get('/api/scores/neon-growth');
         if (!res || !res.ok) throw new Error('fetch failed');
@@ -255,9 +246,18 @@
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }
-
-    loadMiniLeaderboard();
     window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
   </script>
   <script src="game.js" type="module"></script>
 </body>

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -246,18 +246,9 @@
       }, { passive: false });
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      const logoutBtn = document.getElementById('nav-logout-btn');
-      if (logoutBtn) {
-        logoutBtn.addEventListener('click', (e) => {
-          e.preventDefault();
-          api.logout();
-        });
-      }
-    });
-
     async function loadMiniLeaderboard() {
       const list = document.getElementById('lb-list');
+      if (!list) return;
       try {
         const res = await api.get('/api/scores/space-invaders');
         if (!res || !res.ok) throw new Error('fetch failed');
@@ -290,9 +281,18 @@
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }
-
-    loadMiniLeaderboard();
     window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
   </script>
   <script src="game.js"></script>
 </body>

--- a/src/routes/scores.js
+++ b/src/routes/scores.js
@@ -3,7 +3,7 @@ import { authenticate } from '../middleware/auth.js';
 
 const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders'];
 const MAX_SCORE = 999999;
-const RATE_LIMIT_WINDOW_MS = 30 * 1000; // 30 seconds
+const RATE_LIMIT_WINDOW_MS = 3 * 1000; // 3 seconds — prevents double-submit without blocking back-to-back games
 
 // In-memory rate limiter: key = `userId:gameId` -> timestamp of last submission
 const lastSubmission = new Map();
@@ -47,7 +47,7 @@ async function scoresRoutes(fastify) {
     const userId = request.user.id;
 
     if (isRateLimited(userId, game)) {
-      return reply.code(429).send({ error: 'Rate limit exceeded. Max 1 submission per game per 30 seconds.' });
+      return reply.code(429).send({ error: 'Rate limit exceeded. Please wait a few seconds before submitting again.' });
     }
 
     const row = db.prepare(


### PR DESCRIPTION
## Summary

Fixes 2 bugs reported by Adriaan from direct testing on staging:

- **#41 Leaderboard empty on load**: Moved `loadMiniLeaderboard()` call inside `DOMContentLoaded` on all 3 game pages (pacmaze, snake, space-invaders). Added null-check guard on the list element. Ensures the DOM is fully ready and the API fetch fires reliably on page load.

- **#42 Rate limiter too aggressive**: Reduced rate limit window from 30s to 3s. This prevents double-submit/API spam while allowing legitimate back-to-back games. Updated the 429 error message to match.

### Codex Review
- Fixed Major: 429 error message still said "30 seconds" — updated to generic message
- Minor: rate-limit test still references "30s" in description — cosmetic, test logic still valid

### Test Evidence
All 188 tests pass: `JWT_SECRET=test-secret CORS_ORIGIN=http://localhost:3000 DB_PATH=:memory: npm test`

Closes #41, #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed game page initialization to ensure all components load correctly and prevent errors when elements are unavailable.
  * Added protective checks for leaderboard display on game pages.

* **Improvements**
  * Reduced score submission cooldown from 30 seconds to 3 seconds, allowing players to submit scores more frequently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->