### PR TITLE
fix: replace innerHTML template literal with createElement in Pac-Maze overlay

### DIFF
--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -509,15 +509,23 @@
   function showOverlay(title, msg, btnText, btnAction) {
     const overlay = document.getElementById('overlay');
     overlay.style.display = 'flex';
-    overlay.innerHTML = `
-      <h2>${title}</h2>
-      <p>${msg}</p>
-      <button id="overlay-btn">${btnText}</button>
-    `;
-    document.getElementById('overlay-btn').addEventListener('click', () => {
+    overlay.innerHTML = '';
+
+    const h2 = document.createElement('h2');
+    h2.textContent = title;
+
+    const p = document.createElement('p');
+    p.textContent = msg;
+
+    const btn = document.createElement('button');
+    btn.id = 'overlay-btn';
+    btn.textContent = btnText;
+    btn.addEventListener('click', () => {
       overlay.style.display = 'none';
       btnAction();
     });
+
+    overlay.append(h2, p, btn);
   }
 
   function showOverlayMessage(msg) {


### PR DESCRIPTION
## Summary

Refactors `showOverlay()` in `public/games/pacmaze/game.js` to use `createElement`/`textContent` instead of `innerHTML` with interpolated template literals.

- **What:** Replaced `overlay.innerHTML = \`<h2>${title}</h2>...\`` with individual `createElement` calls using `textContent`
- **Why:** Eliminates a potential XSS vector (audit finding M1 in #44). While all current callers pass hardcoded strings, this pattern is inconsistent with Snake and Space Invaders (which both use the safe `createElement` pattern) and would become exploitable if any future change passes API-sourced data
- **Risk:** Minimal — behavioral parity with the original, just uses safe DOM APIs

## Codex Review Summary

Codex (GPT-5.4) found **no Critical or Major issues**. Two Minor notes:
1. Missing `.gitignore` rule for `data/` — pre-existing, out of scope
2. No DOM test for overlay rendering — `textContent` is inherently safe; disproportionate to add browser-level tests for this

All existing tests pass (42/42 pacmaze, 24/24 frontend).

## Test Evidence

```
# tests 42
# pass 42
# fail 0

# tests 24
# pass 24
# fail 0
```

Closes #44 (M1 finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated overlay display implementation for improved stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->