### PR TITLE
fix: add error logging to silent catches and guard localStorage parseInt

### DIFF
--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -502,7 +502,10 @@
           showOverlayMessage('Score could not be saved');
         }
       })
-      .catch(() => showOverlayMessage('Score could not be saved'));
+      .catch((err) => {
+        console.error('Score submission failed:', err);
+        showOverlayMessage('Score could not be saved');
+      });
   }
 
   // -- Overlay helpers ------------------------------------------------------------

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -226,7 +226,8 @@
           li.append(rankSpan, nameSpan, scoreSpan);
           list.appendChild(li);
         }
-      } catch {
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }

--- a/public/games/snake/game.js
+++ b/public/games/snake/game.js
@@ -353,7 +353,10 @@ class NeonGrowth {
           this._showOverlayMessage('Score could not be saved');
         }
       })
-      .catch(() => this._showOverlayMessage('Score could not be saved'));
+      .catch((err) => {
+        console.error('Score submission failed:', err);
+        this._showOverlayMessage('Score could not be saved');
+      });
 
     this._showGameOver();
   }

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -242,7 +242,8 @@
           li.append(rankSpan, nameSpan, scoreSpan);
           list.appendChild(li);
         }
-      } catch {
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }

--- a/public/games/space-invaders/game.js
+++ b/public/games/space-invaders/game.js
@@ -720,7 +720,8 @@ class AsteroidDefenseRenderer {
     this._lastTime = 0;
     this._running = false;
 
-    this.highScore = parseInt(localStorage.getItem('asteroidDefenseHighScore') ?? '0', 10);
+    const raw = parseInt(localStorage.getItem('asteroidDefenseHighScore') ?? '0', 10);
+    this.highScore = Number.isFinite(raw) ? raw : 0;
 
     this._bindKeys();
   }
@@ -917,7 +918,10 @@ class AsteroidDefenseRenderer {
           this._showOverlayMessage('Score could not be saved');
         }
       })
-      .catch(() => this._showOverlayMessage('Score could not be saved'));
+      .catch((err) => {
+        console.error('Score submission failed:', err);
+        this._showOverlayMessage('Score could not be saved');
+      });
 
     this._showGameOver(state);
   }

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -277,7 +277,8 @@
           li.append(rankSpan, nameSpan, scoreSpan);
           list.appendChild(li);
         }
-      } catch {
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
         list.innerHTML = '<li class="lb-empty">Failed to load</li>';
       }
     }

--- a/public/index.html
+++ b/public/index.html
@@ -95,8 +95,8 @@
               topEl.textContent = 'TOP: ' + scores[0].username + ' - ' + scores[0].score.toLocaleString();
             }
           }
-        } catch {
-          // Silently fail -- game card still shows "TOP: ---"
+        } catch (err) {
+          console.error('Failed to load top score for', game.id, err);
         }
       }
     }

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -49,7 +49,8 @@ const api = (() => {
       } else {
         _user = null;
       }
-    } catch {
+    } catch (err) {
+      console.warn('getUser network error:', err);
       _user = null;
     }
     _checked = true;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -10,7 +10,8 @@ export async function authenticate(request, reply) {
       return reply.code(401).send({ ok: false, error: 'Unauthorized' });
     }
     request.user = await request.jwtVerify({ onlyCookie: true });
-  } catch {
+  } catch (err) {
+    request.log.warn({ errCode: err.code, errMessage: err.message }, 'JWT verification failed');
     return reply.code(401).send({ ok: false, error: 'Unauthorized' });
   }
 }


### PR DESCRIPTION
## Summary

Addresses audit findings m1-m5 from #44:

- **m1:** `src/middleware/auth.js` — log `err.code`/`err.message` at warn level before returning 401, so JWT misconfigurations are diagnosable
- **m2:** `public/js/api.js` — `console.warn` network errors in `getUser()` to distinguish auth failure from network-down
- **m3:** Mini-leaderboard catch blocks (home + 3 games) — add `console.error(err)` for diagnostic context
- **m4:** Score submission `.catch()` (3 games) — add `console.error('Score submission failed:', err)` before showing user message
- **m5:** `public/games/space-invaders/game.js` — guard `parseInt` of localStorage high score with `Number.isFinite` to prevent `NaN` from corrupted values

## Files Changed (9)

| File | Change |
|------|--------|
| `src/middleware/auth.js` | Warn-log JWT errors |
| `public/js/api.js` | Warn-log network errors |
| `public/index.html` | Log top-score fetch errors |
| `public/games/pacmaze/index.html` | Log leaderboard errors |
| `public/games/snake/index.html` | Log leaderboard errors |
| `public/games/space-invaders/index.html` | Log leaderboard errors |
| `public/games/pacmaze/game.js` | Log score submission errors |
| `public/games/snake/game.js` | Log score submission errors |
| `public/games/space-invaders/game.js` | Log score submission errors + NaN guard |

## Codex Review Summary

Codex found no issues with the diff itself. Flagged the pre-existing `.gitignore` missing `data/` — out of scope for this PR.

## Test Evidence

```
# tests 101
# pass 101
# fail 0
```

Addresses m1-m5 from #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and logging throughout the application to capture exception details when operations fail, including score submissions, leaderboard loading, authentication, and API requests. This enables better visibility and diagnostics when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->