### PR TITLE
fix: responsive Space Invaders layout for mobile (375px)

### DIFF
--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -140,6 +140,34 @@
       .game-layout { flex-direction: column; align-items: center; }
       .game-leaderboard { max-width: 100%; min-width: 280px; }
     }
+    @media (max-width: 480px) {
+      #hud {
+        font-size: 0.7rem;
+        gap: 0.4rem 0.8rem;
+      }
+      #overlay {
+        overflow-y: auto;
+        gap: 0.4rem;
+        padding: 0.5rem;
+      }
+      #overlay h2 {
+        font-size: 1.1rem;
+        letter-spacing: 0.1em;
+      }
+      #overlay p {
+        font-size: 0.7rem;
+        max-width: 95%;
+        line-height: 1.3;
+      }
+      #overlay button {
+        font-size: 0.85rem;
+        padding: 0.35rem 1.2rem;
+      }
+      #legend {
+        font-size: 0.6rem;
+        gap: 0.4rem 0.8rem;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary

Fixes two mobile layout issues on the Asteroid Defense Surge game page at 375px viewport:

1. **Overlay content overflow** — The start overlay (title + instructions + START GAME button) overflowed the scaled-down canvas area, causing the button to overlap with the weapon legend below. Fixed by adding a mobile media query that reduces font sizes, gaps, and adds `overflow-y: auto` to the overlay.

2. **HUD truncation** — SHIELD and WEAPON values were cut off on narrow screens. Fixed by reducing HUD font size and gap so all five items wrap naturally across two rows.

## Changes

Single file: `public/games/space-invaders/index.html` — added `@media (max-width: 480px)` block with responsive styles for `#hud`, `#overlay`, and `#legend`.

## Codex Review Summary

No Critical or Major issues. Two Minor notes (pre-existing `.gitignore` gap and no CSS test coverage) — both out of scope.

## Test Evidence

```
# tests 188
# pass 188
# fail 0
```

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)