### PR TITLE
fix: legend overlay positioning for mobile (#49)

### DIFF
--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -42,7 +42,7 @@
       flex-wrap: wrap;
       justify-content: center;
     }
-    #canvas-wrapper { position: relative; max-width: 100%; }
+    #canvas-wrapper { position: relative; max-width: 100%; z-index: 1; }
     canvas {
       display: block;
       border: 2px solid #f0f;


### PR DESCRIPTION
## Summary

- Adds `z-index: 1` to `#canvas-wrapper` so the overlay (containing START GAME button) paints above the `#legend` div on mobile viewports where the scaled-down canvas causes visual overlap

## Root Cause

PR #48 fixed canvas scaling for mobile but didn't address the stacking order between `#canvas-wrapper` (containing the absolutely-positioned `#overlay`) and the `#legend` div (a later DOM sibling). On mobile at 375px, the scaled-down canvas puts the START GAME button at the same vertical position as the legend, and the legend painted on top due to DOM order, intercepting all pointer events.

## Test Plan

- [x] Playwright verified at 375x812: START GAME button visible and tappable
- [x] Game starts successfully after tapping START GAME on mobile
- [x] Legend remains visible below canvas during gameplay
- [x] Desktop layout unaffected

## Codex Review

No issues found. Codex confirmed the z-index stacking context fix is correct and low-risk.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layering of game elements in the Space Invaders game to ensure proper element visibility and stacking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->