### PR TITLE
fix: mobile leaderboard, Pac-Maze HUD init, Space Invaders HUD (#50-52)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -282,6 +282,8 @@ a:hover {
 /* ---------- Tables ---------- */
 .table-wrap {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  max-width: 100%;
 }
 
 table {
@@ -315,6 +317,12 @@ tbody tr:hover {
 tbody tr.highlight-self {
   background: rgba(255,215,0,0.08);
   color: var(--neon-gold);
+}
+
+@media (max-width: 480px) {
+  table { min-width: 0; font-size: 0.7rem; }
+  thead th { padding: 6px 4px; font-size: 0.4rem; letter-spacing: 0; }
+  tbody td { padding: 6px 4px; }
 }
 
 .rank-1 { color: var(--neon-gold); font-weight: bold; }
@@ -445,7 +453,7 @@ canvas {
 
 .game-main {
   max-width: 100%;
-  overflow: hidden;
+  overflow-x: clip;
 }
 
 .game-main h1,

--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -113,7 +113,7 @@
   // -- Game state -----------------------------------------------------------------
   let canvas, ctx;
   let state = 'menu'; // 'menu' | 'playing' | 'dead' | 'gameover' | 'levelcomplete'
-  let score, lives, level, mazeIndex;
+  let score = 0, lives = 3, level = 1, mazeIndex = 0;
   let map;           // current mutable map (copy of MAZES[mazeIndex])
   let totalDots;
   let player;

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -19,7 +19,7 @@
       flex-direction: column;
       align-items: center;
       max-width: 100%;
-      overflow: hidden;
+      overflow-x: clip;
     }
     .game-main h1 {
       color: #FFD700;

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -20,7 +20,7 @@
       align-items: center;
       user-select: none;
       max-width: 100%;
-      overflow: hidden;
+      overflow-x: clip;
     }
     .game-main h1 {
       font-size: 1.5rem;

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -20,7 +20,7 @@
       align-items: center;
       user-select: none;
       max-width: 100%;
-      overflow: hidden;
+      overflow-x: clip;
     }
     .game-main h1 {
       font-size: 1.4rem;


### PR DESCRIPTION
## Summary

- **#50 — Leaderboard table truncated on mobile**: Removed `min-width: 520px` on mobile (`@media 480px`), reduced table font/padding so 5 of 6 columns are visible at 375px (up from 3.5). Remaining column accessible via horizontal scroll (`overflow-x: auto` + `-webkit-overflow-scrolling: touch`)
- **#51 — Pac-Maze HUD empty before start**: Initialized `score=0, lives=3, level=1, mazeIndex=0` so `updateHUD()` on page load shows correct values instead of `undefined`
- **#52 — Space Invaders HUD clipped on mobile**: Changed `.game-main` from `overflow: hidden` to `overflow-x: clip` across all game pages + main.css. This clips horizontal overflow (canvas) without forcing vertical clip, so wrapped HUD rows remain visible

## Test Plan

- [x] Pac-Maze HUD shows "SCORE: 0  LIVES: 3  LEVEL: 1" on load (verified via Playwright evaluate)
- [x] Space Invaders HUD shows all 5 stats at 375px (SCORE, WAVE, LIVES, SHIELD, WEAPON)
- [x] Leaderboard table shows 5/6 columns at 375px, 6th accessible via scroll
- [x] START GAME button still tappable on all games

## Codex Review

No issues found. Codex confirmed all changes are correct and low-risk.

Closes #50, closes #51, closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)