### PR TITLE
fix: mobile leaderboard truncation at 375px (#55)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -320,9 +320,23 @@ tbody tr.highlight-self {
 }
 
 @media (max-width: 480px) {
-  table { min-width: 0; font-size: 0.7rem; }
-  thead th { padding: 6px 4px; font-size: 0.4rem; letter-spacing: 0; }
-  tbody td { padding: 6px 4px; }
+  .container { padding: 0 12px; }
+  table { min-width: 0; font-size: 0.65rem; table-layout: fixed; width: 100%; }
+  thead th { padding: 6px 3px; font-size: 0.35rem; letter-spacing: 0; white-space: normal; }
+  tbody td { padding: 6px 3px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .tab-btn { padding: 8px 10px; font-size: 0.45rem; }
+
+  /* Overall tab: hide per-game breakdown columns (4-6) on mobile.
+     Total Pts remains visible; per-game detail lives in the Per Game tab. */
+  #tab-overall th:nth-child(n+4),
+  #tab-overall td:nth-child(n+4) { display: none; }
+
+  /* Per Game tab: size columns for 375px viewport */
+  #tab-per-game table { table-layout: fixed; }
+  #tab-per-game col:nth-child(1) { width: 38px; }
+  #tab-per-game col:nth-child(2) { width: auto; }
+  #tab-per-game col:nth-child(3) { width: 64px; }
+  #tab-per-game col:nth-child(4) { width: 72px; }
 }
 
 .rank-1 { color: var(--neon-gold); font-weight: bold; }

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -63,6 +63,12 @@
       <div class="loading" id="game-loading">LOADING...</div>
       <div class="table-wrap" id="game-table-wrap" style="display:none;">
         <table>
+          <colgroup>
+            <col/>
+            <col/>
+            <col/>
+            <col/>
+          </colgroup>
           <thead>
             <tr>
               <th>Rank</th>


### PR DESCRIPTION
## Summary

- **Overall tab**: Hide per-game breakdown columns (Pac-Maze, Neon Growth, Asteroid Def.) on mobile (<480px). Rank, Player, and Total Pts remain visible — individual game scores are accessible via the Per Game tab.
- **Per Game tab**: Add `<colgroup>` with explicit column widths and `table-layout: fixed` so all 4 columns (Rank, Player, Score, Date) fit within 375px viewport.
- Tighten container padding, th/td padding, and font sizes for mobile.

## Test evidence

```
# pass 42
# fail 0
# duration_ms 7172
```

All existing tests pass. Changes are CSS/HTML only — no server logic modified.

## Test plan

- [ ] Verify Overall tab at 375px: only Rank, Player, Total Pts visible
- [ ] Verify Per Game tab at 375px: all 4 columns visible without horizontal scroll
- [ ] Verify desktop layout is unchanged
- [ ] Visual QA on staging after deploy

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile table layouts with fixed widths and better content handling on small screens.
  * Enhanced mobile interface styling for improved usability.
  * Optimized column structure and visibility for mobile viewports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->