### PR TITLE
fix: prevent stale CDN cache from blocking ghost fix deploy (#57)

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -37,6 +37,8 @@ await app.register(fastifyCors, {
 await app.register(fastifyStatic, {
   root: path.join(__dirname, '..', 'public'),
   prefix: '/',
+  maxAge: 0,
+  cacheControl: true,
 });
 
 // Routes


### PR DESCRIPTION
## Summary

- **Root cause identified**: PR #60's ghost house escape fix was correctly deployed to the origin server, but **Cloudflare's CDN was serving a cached copy of the old `game.js`** with `cache-control: public, max-age=14400` (4 hours). QA tested during this cache window, so ghosts appeared still stuck.
- **Fix**: Set `maxAge: 0` on Fastify's static file plugin so CDNs always revalidate with the origin. This ensures future deploys take effect immediately.
- The ghost escape logic from PR #60 is confirmed working — Playwright testing on the local server shows all 5 ghosts actively escaping the ghost house and roaming the maze within seconds of game start.

## Evidence

**Staging was serving pre-PR-#60 code** (confirmed via `fetch('/games/pacmaze/game.js')`):
- `hasPrevX: false`, `hasMoveStart: false`, `hasInterpolate: false` — none of the PR #60 interpolation markers present
- Old code had `getValidDirs(ghost.col, ghost.row, false)` — hardcoded `false` for `allowHouse`, permanently trapping ghosts in the ghost house

**Response headers from staging**:
```
cache-control: public, max-age=14400
cf-cache-status: EXPIRED
```

**After CF cache expired**, origin serves correct code:
```bash
$ curl -s .../game.js | grep -c "prevX\|moveStart\|function interpolate"
31  # PR #60 code present
```

**Local Playwright test** (with this fix): ghost positions change every sample — confirmed moving at t=2s and t=6s with completely different coordinates.

## Test plan

- [x] All 188 unit tests pass (`npm test`)
- [x] Playwright: ghosts escape house and move (local, PR #60 code)
- [x] Playwright: staging now serves correct game.js (CF cache expired)
- [ ] After deploy: verify `cache-control: public, max-age=0` in response headers
- [ ] After deploy: confirm ghosts move on staging

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated static file serving configuration to ensure users receive the latest versions of assets without local browser caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->