### PR TITLE
fix: faster ghost release + direct position updates (issue #57)

### DIFF
--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -147,7 +147,7 @@
 
   // Ghost release timer
   let releaseTimer = 0;
-  const RELEASE_INTERVAL = 3000;
+  const RELEASE_INTERVAL = 1000;
 
   // -- Canvas setup ---------------------------------------------------------------
   function setupCanvas() {
@@ -356,6 +356,9 @@
     // Tunnel wrap
     ghost.col = ((ghost.col % COLS) + COLS) % COLS;
     ghost.row = ((ghost.row % ROWS) + ROWS) % ROWS;
+    // Direct position update (ensures visual movement even without interpolation)
+    ghost.x = ghost.col * CELL + CELL / 2;
+    ghost.y = ghost.row * CELL + CELL / 2;
   }
 
   // -- Player movement ------------------------------------------------------------

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -244,6 +244,6 @@
       loadMiniLeaderboard();
     });
   </script>
-  <script src="game.js?v=2"></script>
+  <script src="game.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Closes #57 — Ghosts still appeared stuck after PR #60 and PR #64 due to two remaining issues:

1. **RELEASE_INTERVAL too slow (3000ms → 1000ms)**: With 5 ghosts at 3s intervals, the last ghost wasn't released until 12s. Reduced to 1s so all 4 non-Blinky ghosts are released within 4s.

2. **Missing direct position update in moveGhost()**: After updating `ghost.col`/`ghost.row`, the pixel coordinates (`ghost.x`/`ghost.y`) weren't immediately synced. Added direct assignment after each move to ensure visual movement regardless of interpolation timing.

3. **Cache-bust bump (`?v=2` → `?v=3`)**: Ensures CDN delivers the updated game.js.

## Changes

- `public/games/pacmaze/game.js`: `RELEASE_INTERVAL: 3000 → 1000`, added `ghost.x`/`ghost.y` sync in `moveGhost()`
- `public/games/pacmaze/index.html`: cache-bust `?v=3`

## Test plan

- [ ] All 5 ghosts visible and moving within 5 seconds of game start
- [ ] Ghosts actively chase Pac-Man (not frozen in ghost house)
- [ ] Power pellets still make ghosts scared/edible
- [ ] No canvas rendering regressions
- [ ] Touch/keyboard controls still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)