### PR TITLE
fix: add favicon.svg to resolve 404 errors (#61)

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>404 — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
 </head>

--- a/public/auth/login.html
+++ b/public/auth/login.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Login — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
 </head>

--- a/public/auth/register.html
+++ b/public/auth/register.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Register — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
 </head>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="4" fill="#0a0a0f"/>
+  <!-- Joystick base -->
+  <rect x="8" y="22" width="16" height="4" rx="1" fill="#1a1a2e" stroke="#00ffff" stroke-width="0.75"/>
+  <!-- Joystick stick -->
+  <rect x="14" y="10" width="4" height="14" rx="1" fill="#1a1a2e" stroke="#00ffff" stroke-width="0.75"/>
+  <!-- Joystick knob -->
+  <circle cx="16" cy="9" r="5" fill="#0a0a0f" stroke="#ff00ff" stroke-width="1.5"/>
+  <circle cx="16" cy="9" r="2.5" fill="#ff00ff" opacity="0.6"/>
+  <!-- Neon glow dots -->
+  <circle cx="5" cy="5" r="1.5" fill="#00ffff" opacity="0.8"/>
+  <circle cx="27" cy="5" r="1.5" fill="#ff00ff" opacity="0.8"/>
+  <circle cx="5" cy="27" r="1.5" fill="#ff00ff" opacity="0.8"/>
+  <circle cx="27" cy="27" r="1.5" fill="#00ffff" opacity="0.8"/>
+</svg>

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Pac-Maze Rush — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Neon Growth — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Asteroid Defense Surge — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
 </head>

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Leaderboard — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
 </head>


### PR DESCRIPTION
## Summary
- Adds an SVG favicon with retro neon arcade aesthetic (joystick icon with cyan/pink neon colors on dark background)
- Adds `<link rel="icon">` tag to all 8 HTML pages in `public/`
- Resolves the 404 console error on every page load

Closes #61

## Test plan
- [ ] No more 404 for /favicon.ico in browser console
- [ ] Favicon displays in browser tab with neon joystick icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated favicon display across all pages to ensure consistent browser tab icon appearance throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->