### PR TITLE
feat: add Tetris game — Neon Stack (#66)

### DIFF
--- a/public/games/tetris/game.js
+++ b/public/games/tetris/game.js
@@ -1,0 +1,688 @@
+/**
+ * Neon Stack — Tetris with neon glow aesthetic
+ * All 7 tetrominoes, SRS wall kicks, ghost piece, hold, next preview,
+ * line clearing with scoring, level progression, score submission.
+ */
+(function () {
+  'use strict';
+
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+  const CANVAS_W = 700;
+  const CANVAS_H = 520;
+
+  // ── Playfield geometry ────────────────────────────────────────────────────
+  const COLS = 10;
+  const ROWS = 20;
+  const CELL = 24;
+  const FIELD_W = COLS * CELL;          // 240
+  const FIELD_H = ROWS * CELL;          // 480
+  const FIELD_X = Math.floor((CANVAS_W - FIELD_W) / 2);   // centered
+  const FIELD_Y = Math.floor((CANVAS_H - FIELD_H) / 2);   // centered
+
+  // ── Side panel positions ──────────────────────────────────────────────────
+  const HOLD_X = FIELD_X - 130;
+  const HOLD_Y = FIELD_Y + 10;
+  const NEXT_X = FIELD_X + FIELD_W + 20;
+  const NEXT_Y = FIELD_Y + 10;
+
+  // ── Tetromino definitions ─────────────────────────────────────────────────
+  // Each piece has 4 rotation states (0, 1, 2, 3)
+  const PIECES = {
+    I: {
+      color: '#0ff',
+      states: [
+        [[0,0,0,0],[1,1,1,1],[0,0,0,0],[0,0,0,0]],
+        [[0,0,1,0],[0,0,1,0],[0,0,1,0],[0,0,1,0]],
+        [[0,0,0,0],[0,0,0,0],[1,1,1,1],[0,0,0,0]],
+        [[0,1,0,0],[0,1,0,0],[0,1,0,0],[0,1,0,0]],
+      ],
+    },
+    O: {
+      color: '#ff0',
+      states: [
+        [[1,1],[1,1]],
+        [[1,1],[1,1]],
+        [[1,1],[1,1]],
+        [[1,1],[1,1]],
+      ],
+    },
+    T: {
+      color: '#a0f',
+      states: [
+        [[0,1,0],[1,1,1],[0,0,0]],
+        [[0,1,0],[0,1,1],[0,1,0]],
+        [[0,0,0],[1,1,1],[0,1,0]],
+        [[0,1,0],[1,1,0],[0,1,0]],
+      ],
+    },
+    S: {
+      color: '#0f0',
+      states: [
+        [[0,1,1],[1,1,0],[0,0,0]],
+        [[0,1,0],[0,1,1],[0,0,1]],
+        [[0,0,0],[0,1,1],[1,1,0]],
+        [[1,0,0],[1,1,0],[0,1,0]],
+      ],
+    },
+    Z: {
+      color: '#f00',
+      states: [
+        [[1,1,0],[0,1,1],[0,0,0]],
+        [[0,0,1],[0,1,1],[0,1,0]],
+        [[0,0,0],[1,1,0],[0,1,1]],
+        [[0,1,0],[1,1,0],[1,0,0]],
+      ],
+    },
+    J: {
+      color: '#00f',
+      states: [
+        [[1,0,0],[1,1,1],[0,0,0]],
+        [[0,1,1],[0,1,0],[0,1,0]],
+        [[0,0,0],[1,1,1],[0,0,1]],
+        [[0,1,0],[0,1,0],[1,1,0]],
+      ],
+    },
+    L: {
+      color: '#ff8800',
+      states: [
+        [[0,0,1],[1,1,1],[0,0,0]],
+        [[0,1,0],[0,1,0],[0,1,1]],
+        [[0,0,0],[1,1,1],[1,0,0]],
+        [[1,1,0],[0,1,0],[0,1,0]],
+      ],
+    },
+  };
+
+  const PIECE_NAMES = Object.keys(PIECES);
+
+  // ── SRS wall-kick data ────────────────────────────────────────────────────
+  // For J, L, S, T, Z (3x3 pieces)
+  const WALL_KICKS_JLSTZ = {
+    '0>1': [[0,0],[-1,0],[-1,1],[0,-2],[-1,-2]],
+    '1>0': [[0,0],[1,0],[1,-1],[0,2],[1,2]],
+    '1>2': [[0,0],[1,0],[1,-1],[0,2],[1,2]],
+    '2>1': [[0,0],[-1,0],[-1,1],[0,-2],[-1,-2]],
+    '2>3': [[0,0],[1,0],[1,1],[0,-2],[1,-2]],
+    '3>2': [[0,0],[-1,0],[-1,-1],[0,2],[-1,2]],
+    '3>0': [[0,0],[-1,0],[-1,-1],[0,2],[-1,2]],
+    '0>3': [[0,0],[1,0],[1,1],[0,-2],[1,-2]],
+  };
+
+  // For I piece (4x4)
+  const WALL_KICKS_I = {
+    '0>1': [[0,0],[-2,0],[1,0],[-2,-1],[1,2]],
+    '1>0': [[0,0],[2,0],[-1,0],[2,1],[-1,-2]],
+    '1>2': [[0,0],[-1,0],[2,0],[-1,2],[2,-1]],
+    '2>1': [[0,0],[1,0],[-2,0],[1,-2],[-2,1]],
+    '2>3': [[0,0],[2,0],[-1,0],[2,1],[-1,-2]],
+    '3>2': [[0,0],[-2,0],[1,0],[-2,-1],[1,2]],
+    '3>0': [[0,0],[1,0],[-2,0],[1,-2],[-2,1]],
+    '0>3': [[0,0],[-1,0],[2,0],[-1,2],[2,-1]],
+  };
+
+  // ── Scoring ───────────────────────────────────────────────────────────────
+  const LINE_SCORES = [0, 100, 300, 500, 800];
+
+  // ── Game state ────────────────────────────────────────────────────────────
+  let board = [];           // ROWS x COLS, each cell null or color string
+  let currentPiece = null;  // { name, rotation, x, y }
+  let nextPiece = null;
+  let holdPiece = null;
+  let holdUsed = false;     // can only hold once per drop
+  let score = 0;
+  let level = 1;
+  let lines = 0;
+  let gameOver = false;
+  let running = false;
+  let dropInterval = 1000;
+  let dropAccumulator = 0;
+  let lastTime = 0;
+  let bag = [];
+
+  // ── HUD elements ──────────────────────────────────────────────────────────
+  const scoreEl = document.getElementById('score');
+  const levelEl = document.getElementById('level');
+  const linesEl = document.getElementById('lines');
+  const overlay = document.getElementById('overlay');
+  const startBtn = document.getElementById('start-btn');
+
+  // ── 7-bag random generator ────────────────────────────────────────────────
+  function refillBag() {
+    bag = [...PIECE_NAMES];
+    // Fisher-Yates shuffle
+    for (let i = bag.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [bag[i], bag[j]] = [bag[j], bag[i]];
+    }
+  }
+
+  function nextFromBag() {
+    if (bag.length === 0) refillBag();
+    return bag.pop();
+  }
+
+  // ── Board helpers ─────────────────────────────────────────────────────────
+  function createBoard() {
+    const b = [];
+    for (let r = 0; r < ROWS; r++) {
+      b.push(new Array(COLS).fill(null));
+    }
+    return b;
+  }
+
+  function getShape(name, rotation) {
+    return PIECES[name].states[rotation];
+  }
+
+  function collides(name, rotation, px, py) {
+    const shape = getShape(name, rotation);
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (!shape[r][c]) continue;
+        const bx = px + c;
+        const by = py + r;
+        if (bx < 0 || bx >= COLS || by >= ROWS) return true;
+        if (by >= 0 && board[by][bx] !== null) return true;
+      }
+    }
+    return false;
+  }
+
+  function lockPiece() {
+    const shape = getShape(currentPiece.name, currentPiece.rotation);
+    const color = PIECES[currentPiece.name].color;
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (!shape[r][c]) continue;
+        const bx = currentPiece.x + c;
+        const by = currentPiece.y + r;
+        if (by >= 0 && by < ROWS && bx >= 0 && bx < COLS) {
+          board[by][bx] = color;
+        }
+      }
+    }
+  }
+
+  function clearLines() {
+    let cleared = 0;
+    for (let r = ROWS - 1; r >= 0; r--) {
+      if (board[r].every(cell => cell !== null)) {
+        board.splice(r, 1);
+        board.unshift(new Array(COLS).fill(null));
+        cleared++;
+        r++; // recheck same row index
+      }
+    }
+    return cleared;
+  }
+
+  function ghostY() {
+    let gy = currentPiece.y;
+    while (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x, gy + 1)) {
+      gy++;
+    }
+    return gy;
+  }
+
+  // ── Piece spawn ───────────────────────────────────────────────────────────
+  function spawnPiece(name) {
+    const shape = getShape(name, 0);
+    const px = Math.floor((COLS - shape[0].length) / 2);
+    const py = -1;  // start just above visible area
+    if (collides(name, 0, px, py)) {
+      // game over
+      return null;
+    }
+    return { name, rotation: 0, x: px, y: py };
+  }
+
+  function spawnNext() {
+    currentPiece = nextPiece ? { ...nextPiece } : null;
+    if (!currentPiece) {
+      const name = nextFromBag();
+      currentPiece = spawnPiece(name);
+    } else {
+      // Re-spawn with position
+      currentPiece = spawnPiece(currentPiece.name);
+    }
+    const nn = nextFromBag();
+    nextPiece = { name: nn, rotation: 0, x: 0, y: 0 };
+    holdUsed = false;
+
+    if (!currentPiece) {
+      endGame();
+    }
+  }
+
+  // ── Rotation with SRS wall kicks ──────────────────────────────────────────
+  function tryRotate(dir) {
+    if (!currentPiece) return;
+    const oldRot = currentPiece.rotation;
+    const newRot = (oldRot + dir + 4) % 4;
+    const kickTable = currentPiece.name === 'I' ? WALL_KICKS_I : (currentPiece.name === 'O' ? null : WALL_KICKS_JLSTZ);
+
+    if (!kickTable) {
+      // O piece: no kicks needed, rotation is identity
+      return;
+    }
+
+    const key = oldRot + '>' + newRot;
+    const kicks = kickTable[key];
+    if (!kicks) return;
+
+    for (const [dx, dy] of kicks) {
+      if (!collides(currentPiece.name, newRot, currentPiece.x + dx, currentPiece.y - dy)) {
+        currentPiece.rotation = newRot;
+        currentPiece.x += dx;
+        currentPiece.y -= dy;
+        return;
+      }
+    }
+  }
+
+  // ── Hold piece ────────────────────────────────────────────────────────────
+  function doHold() {
+    if (!currentPiece || holdUsed) return;
+    holdUsed = true;
+    const heldName = currentPiece.name;
+    if (holdPiece) {
+      const swapName = holdPiece;
+      holdPiece = heldName;
+      currentPiece = spawnPiece(swapName);
+      if (!currentPiece) endGame();
+    } else {
+      holdPiece = heldName;
+      spawnNext();
+    }
+  }
+
+  // ── Movement ──────────────────────────────────────────────────────────────
+  function moveLeft() {
+    if (!currentPiece) return;
+    if (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x - 1, currentPiece.y)) {
+      currentPiece.x--;
+    }
+  }
+
+  function moveRight() {
+    if (!currentPiece) return;
+    if (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x + 1, currentPiece.y)) {
+      currentPiece.x++;
+    }
+  }
+
+  function softDrop() {
+    if (!currentPiece) return;
+    if (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x, currentPiece.y + 1)) {
+      currentPiece.y++;
+      score += 1;
+      updateHud();
+    }
+  }
+
+  function hardDrop() {
+    if (!currentPiece) return;
+    let dist = 0;
+    while (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x, currentPiece.y + 1)) {
+      currentPiece.y++;
+      dist++;
+    }
+    score += dist * 2;
+    lockAndAdvance();
+  }
+
+  function lockAndAdvance() {
+    lockPiece();
+    const cleared = clearLines();
+    if (cleared > 0) {
+      score += LINE_SCORES[cleared] * level;
+      lines += cleared;
+      const newLevel = Math.floor(lines / 10) + 1;
+      if (newLevel > level) {
+        level = newLevel;
+        dropInterval = Math.max(50, 1000 - (level - 1) * 80);
+      }
+    }
+    updateHud();
+    spawnNext();
+  }
+
+  function gravityDrop() {
+    if (!currentPiece) return;
+    if (!collides(currentPiece.name, currentPiece.rotation, currentPiece.x, currentPiece.y + 1)) {
+      currentPiece.y++;
+    } else {
+      lockAndAdvance();
+    }
+  }
+
+  // ── HUD update ────────────────────────────────────────────────────────────
+  function updateHud() {
+    scoreEl.textContent = score.toLocaleString();
+    levelEl.textContent = level;
+    linesEl.textContent = lines;
+  }
+
+  // ── Drawing ───────────────────────────────────────────────────────────────
+  function drawBlock(x, y, color, alpha) {
+    const px = FIELD_X + x * CELL;
+    const py = FIELD_Y + y * CELL;
+    ctx.save();
+    ctx.globalAlpha = alpha || 1;
+    ctx.fillStyle = color;
+    ctx.shadowColor = color;
+    ctx.shadowBlur = 8;
+    ctx.fillRect(px + 1, py + 1, CELL - 2, CELL - 2);
+    ctx.shadowBlur = 0;
+    // Inner highlight
+    ctx.fillStyle = 'rgba(255,255,255,0.15)';
+    ctx.fillRect(px + 2, py + 2, CELL - 6, 3);
+    ctx.restore();
+  }
+
+  function drawBoard() {
+    // Background
+    ctx.fillStyle = '#0a0a0a';
+    ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+    // Field background
+    ctx.fillStyle = '#111';
+    ctx.fillRect(FIELD_X, FIELD_Y, FIELD_W, FIELD_H);
+
+    // Grid lines
+    ctx.strokeStyle = 'rgba(255,255,255,0.05)';
+    ctx.lineWidth = 0.5;
+    for (let r = 0; r <= ROWS; r++) {
+      ctx.beginPath();
+      ctx.moveTo(FIELD_X, FIELD_Y + r * CELL);
+      ctx.lineTo(FIELD_X + FIELD_W, FIELD_Y + r * CELL);
+      ctx.stroke();
+    }
+    for (let c = 0; c <= COLS; c++) {
+      ctx.beginPath();
+      ctx.moveTo(FIELD_X + c * CELL, FIELD_Y);
+      ctx.lineTo(FIELD_X + c * CELL, FIELD_Y + FIELD_H);
+      ctx.stroke();
+    }
+
+    // Locked blocks
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (board[r][c]) {
+          drawBlock(c, r, board[r][c], 1);
+        }
+      }
+    }
+  }
+
+  function drawCurrentPiece() {
+    if (!currentPiece) return;
+    const shape = getShape(currentPiece.name, currentPiece.rotation);
+    const color = PIECES[currentPiece.name].color;
+
+    // Ghost piece
+    const gy = ghostY();
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (!shape[r][c]) continue;
+        const by = gy + r;
+        if (by >= 0) {
+          drawBlock(currentPiece.x + c, by, color, 0.2);
+        }
+      }
+    }
+
+    // Actual piece
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (!shape[r][c]) continue;
+        const by = currentPiece.y + r;
+        if (by >= 0) {
+          drawBlock(currentPiece.x + c, by, color, 1);
+        }
+      }
+    }
+  }
+
+  function drawMiniPiece(name, cx, cy, label) {
+    if (!name) return;
+    const shape = getShape(name, 0);
+    const color = PIECES[name].color;
+    const miniCell = 16;
+
+    // Label
+    ctx.save();
+    ctx.fillStyle = '#ff8800';
+    ctx.shadowColor = '#ff8800';
+    ctx.shadowBlur = 4;
+    ctx.font = '11px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText(label, cx + (shape[0].length * miniCell) / 2, cy - 8);
+    ctx.restore();
+
+    // Draw blocks
+    for (let r = 0; r < shape.length; r++) {
+      for (let c = 0; c < shape[r].length; c++) {
+        if (!shape[r][c]) continue;
+        const px = cx + c * miniCell;
+        const py = cy + r * miniCell;
+        ctx.save();
+        ctx.fillStyle = color;
+        ctx.shadowColor = color;
+        ctx.shadowBlur = 6;
+        ctx.fillRect(px + 1, py + 1, miniCell - 2, miniCell - 2);
+        ctx.shadowBlur = 0;
+        ctx.restore();
+      }
+    }
+  }
+
+  function drawSidePanels() {
+    // Hold panel
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,136,0,0.3)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(HOLD_X - 5, HOLD_Y - 25, 110, 90);
+    ctx.restore();
+    drawMiniPiece(holdPiece, HOLD_X + 15, HOLD_Y + 5, 'HOLD');
+
+    // Next panel
+    ctx.save();
+    ctx.strokeStyle = 'rgba(255,136,0,0.3)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(NEXT_X - 5, NEXT_Y - 25, 110, 90);
+    ctx.restore();
+    if (nextPiece) {
+      drawMiniPiece(nextPiece.name, NEXT_X + 15, NEXT_Y + 5, 'NEXT');
+    }
+
+    // Level/Lines info on right side below Next
+    ctx.save();
+    ctx.fillStyle = '#888';
+    ctx.font = '10px monospace';
+    ctx.textAlign = 'left';
+    ctx.fillText('SPEED: ' + dropInterval + 'ms', NEXT_X, NEXT_Y + 90);
+    ctx.restore();
+  }
+
+  function draw() {
+    drawBoard();
+    drawCurrentPiece();
+    drawSidePanels();
+  }
+
+  // ── Game loop ─────────────────────────────────────────────────────────────
+  function gameLoop(timestamp) {
+    if (!running) return;
+    if (!lastTime) lastTime = timestamp;
+    const dt = timestamp - lastTime;
+    lastTime = timestamp;
+
+    dropAccumulator += dt;
+    if (dropAccumulator >= dropInterval) {
+      dropAccumulator -= dropInterval;
+      gravityDrop();
+    }
+
+    draw();
+    requestAnimationFrame(gameLoop);
+  }
+
+  // ── Game over ─────────────────────────────────────────────────────────────
+  async function endGame() {
+    gameOver = true;
+    running = false;
+
+    // Show overlay with final score
+    overlay.innerHTML = '';
+    const h2 = document.createElement('h2');
+    h2.textContent = 'GAME OVER';
+    const p = document.createElement('p');
+    p.textContent = 'Final Score: ' + score.toLocaleString() + ' | Level: ' + level + ' | Lines: ' + lines;
+    const btn = document.createElement('button');
+    btn.textContent = 'PLAY AGAIN';
+    btn.addEventListener('click', startGame);
+    overlay.append(h2, p, btn);
+    overlay.style.display = 'flex';
+
+    // Submit score
+    try {
+      const user = await api.getUser();
+      if (user) {
+        await api.post('/api/scores/tetris', { score });
+        if (typeof loadMiniLeaderboard === 'function') loadMiniLeaderboard();
+      }
+    } catch (err) {
+      console.error('Score submission failed:', err);
+    }
+  }
+
+  // ── Start game ────────────────────────────────────────────────────────────
+  function startGame() {
+    board = createBoard();
+    score = 0;
+    level = 1;
+    lines = 0;
+    dropInterval = 1000;
+    dropAccumulator = 0;
+    lastTime = 0;
+    gameOver = false;
+    holdPiece = null;
+    holdUsed = false;
+    bag = [];
+    currentPiece = null;
+    nextPiece = null;
+
+    refillBag();
+    const firstName = nextFromBag();
+    nextPiece = { name: firstName, rotation: 0, x: 0, y: 0 };
+    spawnNext();
+
+    updateHud();
+    overlay.style.display = 'none';
+    running = true;
+    requestAnimationFrame(gameLoop);
+  }
+
+  // ── Input handling ────────────────────────────────────────────────────────
+  const keysDown = {};
+
+  document.addEventListener('keydown', (e) => {
+    if (!running || gameOver) return;
+    if (keysDown[e.key]) return; // prevent repeat for rotation/hard-drop
+    keysDown[e.key] = true;
+
+    switch (e.key) {
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        moveLeft();
+        e.preventDefault();
+        break;
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        moveRight();
+        e.preventDefault();
+        break;
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        softDrop();
+        e.preventDefault();
+        break;
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        tryRotate(1);
+        e.preventDefault();
+        break;
+      case ' ':
+        hardDrop();
+        e.preventDefault();
+        break;
+      case 'c':
+      case 'C':
+        doHold();
+        e.preventDefault();
+        break;
+    }
+  });
+
+  document.addEventListener('keyup', (e) => {
+    delete keysDown[e.key];
+  });
+
+  // Allow repeated soft drop & movement when holding key
+  let softDropTimer = null;
+  let moveLeftTimer = null;
+  let moveRightTimer = null;
+
+  document.addEventListener('keydown', (e) => {
+    if (!running || gameOver) return;
+    if (e.key === 'ArrowDown' || e.key === 's' || e.key === 'S') {
+      if (!softDropTimer) {
+        softDropTimer = setInterval(() => {
+          if (running && !gameOver) softDrop();
+        }, 50);
+      }
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') {
+      if (!moveLeftTimer) {
+        moveLeftTimer = setInterval(() => {
+          if (running && !gameOver) moveLeft();
+        }, 80);
+      }
+    }
+    if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') {
+      if (!moveRightTimer) {
+        moveRightTimer = setInterval(() => {
+          if (running && !gameOver) moveRight();
+        }, 80);
+      }
+    }
+  });
+
+  document.addEventListener('keyup', (e) => {
+    if (e.key === 'ArrowDown' || e.key === 's' || e.key === 'S') {
+      clearInterval(softDropTimer);
+      softDropTimer = null;
+    }
+    if (e.key === 'ArrowLeft' || e.key === 'a' || e.key === 'A') {
+      clearInterval(moveLeftTimer);
+      moveLeftTimer = null;
+    }
+    if (e.key === 'ArrowRight' || e.key === 'd' || e.key === 'D') {
+      clearInterval(moveRightTimer);
+      moveRightTimer = null;
+    }
+  });
+
+  // ── Start button ──────────────────────────────────────────────────────────
+  startBtn.addEventListener('click', startGame);
+
+  // Initial draw
+  board = createBoard();
+  draw();
+})();

--- a/public/games/tetris/index.html
+++ b/public/games/tetris/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Neon Stack — Retro Arcade</title>
+  <link rel="stylesheet" href="/css/main.css" />
+  <style>
+    .game-layout {
+      display: flex;
+      gap: 24px;
+      justify-content: center;
+      align-items: flex-start;
+      padding: 20px;
+      flex-wrap: wrap;
+    }
+    .game-main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      user-select: none;
+      max-width: 100%;
+      overflow: hidden;
+    }
+    .game-main h1 {
+      font-size: 1.4rem;
+      letter-spacing: 0.2em;
+      text-shadow: 0 0 10px #ff8800, 0 0 20px #ff8800;
+      margin-bottom: 0.4rem;
+      color: #ff8800;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+    }
+    #hud {
+      display: flex;
+      gap: 1.5rem;
+      font-size: 0.9rem;
+      margin-bottom: 0.4rem;
+      text-shadow: 0 0 6px #0ff;
+      color: #0ff;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    #canvas-wrapper { position: relative; max-width: 100%; }
+    canvas {
+      display: block;
+      border: 2px solid #ff8800;
+      box-shadow: 0 0 20px #ff8800, 0 0 40px #cc6600;
+      max-width: 100%;
+      height: auto;
+    }
+    #overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.82);
+      color: #ff8800;
+      gap: 0.8rem;
+    }
+    #overlay h2 {
+      font-size: 1.8rem;
+      text-shadow: 0 0 10px #ff8800;
+      letter-spacing: 0.2em;
+      font-family: var(--font-pixel);
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+      max-width: 90%;
+    }
+    #overlay p {
+      font-size: 0.95rem;
+      opacity: 0.85;
+      text-align: center;
+      max-width: 380px;
+      line-height: 1.6;
+    }
+    #overlay button {
+      background: transparent;
+      border: 2px solid #ff8800;
+      color: #ff8800;
+      font-family: inherit;
+      font-size: 1.1rem;
+      padding: 0.5rem 2rem;
+      cursor: pointer;
+      text-shadow: 0 0 6px #ff8800;
+      box-shadow: 0 0 10px #ff8800;
+      letter-spacing: 0.1em;
+    }
+    #overlay button:hover { background: rgba(255,136,0,0.1); }
+
+    /* Leaderboard panel */
+    .game-leaderboard {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 16px;
+      min-width: 220px;
+      max-width: 280px;
+    }
+    .game-leaderboard h3 {
+      font-family: var(--font-pixel);
+      font-size: 0.55rem;
+      color: var(--neon-gold);
+      text-shadow: 0 0 6px rgba(255,215,0,0.4);
+      margin-bottom: 12px;
+      text-align: center;
+    }
+    .lb-list { list-style: none; font-size: 0.8rem; }
+    .lb-list li {
+      display: flex;
+      justify-content: space-between;
+      padding: 4px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .lb-list li:last-child { border-bottom: none; }
+    .lb-rank { color: var(--neon-cyan); min-width: 28px; }
+    .lb-name { flex: 1; margin: 0 8px; }
+    .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
+
+    @media (max-width: 900px) {
+      .game-layout { flex-direction: column; align-items: center; }
+      .game-leaderboard { max-width: 100%; min-width: 280px; }
+    }
+    @media (max-width: 480px) {
+      #hud {
+        font-size: 0.7rem;
+        gap: 0.4rem 0.8rem;
+      }
+      #overlay {
+        overflow-y: auto;
+        gap: 0.4rem;
+        padding: 0.5rem;
+      }
+      #overlay h2 {
+        font-size: 1.1rem;
+        letter-spacing: 0.1em;
+      }
+      #overlay p {
+        font-size: 0.7rem;
+        max-width: 95%;
+        line-height: 1.3;
+      }
+      #overlay button {
+        font-size: 0.85rem;
+        padding: 0.35rem 1.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <a href="/" class="navbar-brand">RETRO ARCADE</a>
+    <div class="navbar-links">
+      <a href="/leaderboard.html">Leaderboard</a>
+      <span id="nav-auth-links" style="display:flex;gap:20px;">
+        <a href="/auth/login.html">Login</a>
+        <a href="/auth/register.html">Register</a>
+      </span>
+      <span id="nav-user-info" style="display:none;align-items:center;gap:12px;">
+        <span class="navbar-user" id="nav-username"></span>
+        <a href="#" id="nav-logout-btn">Logout</a>
+      </span>
+    </div>
+  </nav>
+
+  <div class="game-layout">
+    <div class="game-main">
+      <h1>NEON STACK</h1>
+      <div id="hud">
+        <span>SCORE: <span id="score">0</span></span>
+        <span>LEVEL: <span id="level">1</span></span>
+        <span>LINES: <span id="lines">0</span></span>
+      </div>
+      <div id="canvas-wrapper">
+        <canvas id="canvas" width="700" height="520"></canvas>
+        <div id="overlay">
+          <h2>NEON STACK</h2>
+          <p>
+            Arrow keys / WASD — Move &amp; Rotate<br>
+            Up / W — Rotate<br>
+            Down / S — Soft drop<br>
+            Space — Hard drop<br>
+            C — Hold piece
+          </p>
+          <button id="start-btn">START GAME</button>
+        </div>
+      </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="touch-controls-row">
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowDown" style="width:64px;height:64px;font-size:1.6rem;">&#9660;</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+        </div>
+        <div class="touch-controls-row" style="margin-top:8px;">
+          <button class="touch-btn-fire" id="rotate-btn">ROTATE</button>
+          <button class="touch-btn-fire" id="drop-btn">DROP</button>
+        </div>
+        <div class="touch-hint">D-PAD TO MOVE &bull; ROTATE &bull; DROP</div>
+      </div>
+    </div>
+
+    <div class="game-leaderboard">
+      <h3>TOP SCORES</h3>
+      <ul class="lb-list" id="lb-list">
+        <li class="lb-empty">Loading...</li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="/js/api.js"></script>
+  <script>
+    // Touch controls — movement buttons
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      let interval = null;
+      const startMove = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        interval = setInterval(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        }, 80);
+      };
+      const stopMove = (e) => {
+        e.preventDefault();
+        clearInterval(interval);
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', startMove, { passive: false });
+      btn.addEventListener('touchend', stopMove, { passive: false });
+      btn.addEventListener('touchcancel', stopMove, { passive: false });
+    });
+
+    // Rotate button
+    const rotateBtn = document.getElementById('rotate-btn');
+    if (rotateBtn) {
+      rotateBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }));
+      }, { passive: false });
+      rotateBtn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: 'ArrowUp', bubbles: true }));
+      }, { passive: false });
+    }
+
+    // Drop button
+    const dropBtn = document.getElementById('drop-btn');
+    if (dropBtn) {
+      dropBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+      dropBtn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+    }
+
+    async function loadMiniLeaderboard() {
+      const list = document.getElementById('lb-list');
+      if (!list) return;
+      try {
+        const res = await api.get('/api/scores/tetris');
+        if (!res || !res.ok) throw new Error('fetch failed');
+        const scores = await res.json();
+        const user = await api.getUser();
+
+        if (scores.length === 0) {
+          list.innerHTML = '<li class="lb-empty">No scores yet</li>';
+          return;
+        }
+
+        list.innerHTML = '';
+        for (const s of scores) {
+          const isSelf = user && s.username === user.username;
+          const li = document.createElement('li');
+          if (isSelf) li.style.color = 'var(--neon-gold)';
+          const rankSpan = document.createElement('span');
+          rankSpan.className = 'lb-rank';
+          rankSpan.textContent = '#' + s.rank;
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'lb-name';
+          nameSpan.textContent = isSelf ? s.username + ' (YOU)' : s.username;
+          const scoreSpan = document.createElement('span');
+          scoreSpan.className = 'lb-score';
+          scoreSpan.textContent = s.score.toLocaleString();
+          li.append(rankSpan, nameSpan, scoreSpan);
+          list.appendChild(li);
+        }
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
+        list.innerHTML = '<li class="lb-empty">Failed to load</li>';
+      }
+    }
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
+  </script>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -80,6 +80,14 @@
         <div class="card-top-score" id="top-pong">TOP: ---</div>
         <a href="/games/pong/" class="btn" style="border-color:#ffee00;color:#ffee00;box-shadow:0 0 8px rgba(255,238,0,0.2);">PLAY</a>
       </div>
+
+      <!-- Neon Stack -->
+      <div class="card">
+        <h3>NEON STACK</h3>
+        <p>Tetris with neon blocks, ghost pieces, hold queue, and increasing speed. Stack or be stacked.</p>
+        <div class="card-top-score" id="top-tetris">TOP: ---</div>
+        <a href="/games/tetris/" class="btn" style="border-color:#ff8800;color:#ff8800;box-shadow:0 0 8px rgba(255,136,0,0.2);">PLAY</a>
+      </div>
     </div>
 
     <div style="text-align:center;margin:30px 0;">
@@ -102,6 +110,7 @@
         { id: 'space-invaders', el: 'top-space-invaders' },
         { id: 'frogger', el: 'top-frogger' },
         { id: 'pong', el: 'top-pong' },
+        { id: 'tetris', el: 'top-tetris' },
       ];
 
       for (const game of games) {

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -48,6 +48,7 @@
               <th>Asteroid Def.</th>
               <th>Neon Hopper</th>
               <th>Photon Paddle</th>
+              <th>Neon Stack</th>
             </tr>
           </thead>
           <tbody id="overall-tbody"></tbody>
@@ -64,6 +65,7 @@
         <option value="space-invaders">Asteroid Defense Surge</option>
         <option value="frogger">Neon Hopper</option>
         <option value="pong">Photon Paddle</option>
+        <option value="tetris">Neon Stack</option>
       </select>
       <div class="loading" id="game-loading">LOADING...</div>
       <div class="table-wrap" id="game-table-wrap" style="display:none;">
@@ -104,6 +106,7 @@
       'space-invaders': 'Asteroid Def.',
       'frogger': 'Neon Hopper',
       'pong': 'Photon Paddle',
+      'tetris': 'Neon Stack',
     };
 
     // ---- Tab switching ----
@@ -158,6 +161,7 @@
           const spacePts = entry.breakdown?.['space-invaders']?.points ?? 0;
           const froggerPts = entry.breakdown?.['frogger']?.points ?? 0;
           const pongPts = entry.breakdown?.pong?.points ?? 0;
+          const tetrisPts = entry.breakdown?.['tetris']?.points ?? 0;
 
           const rankTd = document.createElement('td');
           rankTd.className = rankClass(entry.rank);
@@ -176,7 +180,9 @@
           froggerTd.textContent = froggerPts;
           const pongTd = document.createElement('td');
           pongTd.textContent = pongPts;
-          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd, pongTd);
+          const tetrisTd = document.createElement('td');
+          tetrisTd.textContent = tetrisPts;
+          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd, pongTd, tetrisTd);
           tbody.appendChild(tr);
         }
 

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { pointsForPosition } from '../utils/f1-points.js';
 
-const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong'];
+const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris'];
 
 /**
  * Computes per-game rankings (best score per user) for a given game.

--- a/src/routes/scores.js
+++ b/src/routes/scores.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
 
-const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong'];
+const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris'];
 const MAX_SCORE = 999999;
 const RATE_LIMIT_WINDOW_MS = 3 * 1000; // 3 seconds — prevents double-submit without blocking back-to-back games
 


### PR DESCRIPTION
## Summary
- Adds complete playable Tetris game (NEON STACK) at /games/tetris/
- All 7 tetrominoes with SRS wall-kick rotation
- Hard drop, soft drop, ghost piece, hold piece, next preview
- 7-bag randomizer, line clear scoring (1/2/3/4 lines) with level progression
- Score submission and mini-leaderboard sidebar
- Mobile touch controls (D-pad + rotate + drop)
- Added to homepage card grid, leaderboard page, VALID_GAMES, GAMES arrays

Closes #66

## Test plan
- [ ] `curl -s http://localhost:3000/games/tetris/ | grep -q "NEON STACK"`
- [ ] Pieces fall, rotate (with wall kicks near edges), clear lines, score increments
- [ ] Ghost piece shows landing position; hold (C key) swaps piece
- [ ] Game over submits score for logged-in users
- [ ] Homepage shows Neon Stack card with orange styling
- [ ] Leaderboard overall table has Neon Stack column; per-game selector has Neon Stack option

🤖 Generated with [Claude Code](https://claude.com/claude-code)