### PR TITLE
feat: add Asteroids game — Void Drifter (#68)

### DIFF
--- a/public/games/asteroids/game.js
+++ b/public/games/asteroids/game.js
@@ -1,0 +1,740 @@
+/**
+ * Void Drifter — Asteroids with neon wireframe rendering
+ * - Vector wireframe ship, asteroids, UFO
+ * - Ship rotation, thrust with friction, screen wrapping
+ * - Asteroids split: large -> 2 medium -> 2 small -> destroyed
+ * - Wave progression, UFO enemy, particle effects
+ * - Lives, invulnerability on respawn, score submission
+ */
+
+const CANVAS_W = 700;
+const CANVAS_H = 520;
+
+// ── Game constants ──────────────────────────────────────────────────────────
+const SHIP_RADIUS = 15;
+const ROTATION_SPEED = 0.065;
+const THRUST_POWER = 0.12;
+const FRICTION = 0.992;
+const MAX_SPEED = 6;
+const MAX_BULLETS = 5;
+const BULLET_SPEED = 7;
+const BULLET_LIFE = 55; // frames
+const BULLET_RADIUS = 2;
+const FIRE_COOLDOWN = 150; // ms
+const INVULN_TIME = 2000; // ms
+const MAX_LIVES = 3;
+const PARTICLE_LIFE = 30; // frames
+
+const ASTEROID_SIZES = {
+  large:  { radius: 40, points: 25,  speed: 1.0, children: 'medium' },
+  medium: { radius: 20, points: 50,  speed: 1.8, children: 'small' },
+  small:  { radius: 10, points: 100, speed: 2.5, children: null },
+};
+
+const UFO_INTERVAL_MIN = 15000; // ms between UFO spawns
+const UFO_INTERVAL_MAX = 30000;
+const UFO_SPEED = 2;
+const UFO_FIRE_RATE = 1500; // ms between UFO shots
+const UFO_RADIUS = 15;
+const UFO_POINTS = 200;
+const UFO_BULLET_SPEED = 4;
+
+// ── Colors ──────────────────────────────────────────────────────────────────
+const COLOR_SHIP = '#33ff88';
+const COLOR_BULLET = '#00ffff';
+const COLOR_ASTEROID = '#cccccc';
+const COLOR_ASTEROID_GLOW = 'rgba(204,204,204,0.3)';
+const COLOR_UFO = '#ff3366';
+const COLOR_UFO_BULLET = '#ff6644';
+const COLOR_PARTICLE = '#33ff88';
+const COLOR_THRUST = '#ff8833';
+
+// ── Canvas & state ──────────────────────────────────────────────────────────
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const overlay = document.getElementById('overlay');
+const startBtn = document.getElementById('start-btn');
+const scoreEl = document.getElementById('score');
+const livesEl = document.getElementById('lives');
+const waveEl = document.getElementById('wave');
+
+let running = false;
+let gameOver = false;
+let score = 0;
+let lives = MAX_LIVES;
+let wave = 0;
+let lastTime = 0;
+let lastFireTime = 0;
+
+// Ship state
+let ship = null;
+
+// Entity arrays
+let bullets = [];
+let asteroids = [];
+let particles = [];
+let ufo = null;
+let ufoBullets = [];
+let ufoTimer = 0;
+let nextUfoTime = 0;
+
+// Input state
+const keys = {};
+
+// ── Utility functions ───────────────────────────────────────────────────────
+function rand(min, max) { return Math.random() * (max - min) + min; }
+function randInt(min, max) { return Math.floor(rand(min, max + 1)); }
+
+function wrap(x, y) {
+  if (x < -50) x += CANVAS_W + 100;
+  if (x > CANVAS_W + 50) x -= CANVAS_W + 100;
+  if (y < -50) y += CANVAS_H + 100;
+  if (y > CANVAS_H + 50) y -= CANVAS_H + 100;
+  return { x, y };
+}
+
+function dist(x1, y1, x2, y2) {
+  return Math.sqrt((x2 - x1) ** 2 + (y2 - y1) ** 2);
+}
+
+function generateAsteroidShape(radius) {
+  const verts = randInt(7, 12);
+  const shape = [];
+  for (let i = 0; i < verts; i++) {
+    const angle = (i / verts) * Math.PI * 2;
+    const r = radius * rand(0.7, 1.3);
+    shape.push({ x: Math.cos(angle) * r, y: Math.sin(angle) * r });
+  }
+  return shape;
+}
+
+// ── Ship ────────────────────────────────────────────────────────────────────
+function createShip() {
+  return {
+    x: CANVAS_W / 2,
+    y: CANVAS_H / 2,
+    vx: 0,
+    vy: 0,
+    angle: -Math.PI / 2, // pointing up
+    thrusting: false,
+    invulnerable: true,
+    invulnTimer: INVULN_TIME,
+    visible: true,
+    flickerTimer: 0,
+  };
+}
+
+function updateShip(dt) {
+  if (!ship) return;
+
+  // Rotation
+  if (keys['ArrowLeft'] || keys['a'] || keys['A']) ship.angle -= ROTATION_SPEED * dt * 60 / 1000;
+  if (keys['ArrowRight'] || keys['d'] || keys['D']) ship.angle += ROTATION_SPEED * dt * 60 / 1000;
+
+  // Thrust
+  ship.thrusting = !!(keys['ArrowUp'] || keys['w'] || keys['W']);
+  if (ship.thrusting) {
+    ship.vx += Math.cos(ship.angle) * THRUST_POWER * dt * 60 / 1000;
+    ship.vy += Math.sin(ship.angle) * THRUST_POWER * dt * 60 / 1000;
+  }
+
+  // Friction
+  const frictionFactor = Math.pow(FRICTION, dt * 60 / 1000);
+  ship.vx *= frictionFactor;
+  ship.vy *= frictionFactor;
+
+  // Cap speed
+  const spd = Math.sqrt(ship.vx ** 2 + ship.vy ** 2);
+  if (spd > MAX_SPEED) {
+    ship.vx = (ship.vx / spd) * MAX_SPEED;
+    ship.vy = (ship.vy / spd) * MAX_SPEED;
+  }
+
+  // Move
+  ship.x += ship.vx * dt * 60 / 1000;
+  ship.y += ship.vy * dt * 60 / 1000;
+
+  // Wrap
+  const w = wrap(ship.x, ship.y);
+  ship.x = w.x;
+  ship.y = w.y;
+
+  // Invulnerability timer
+  if (ship.invulnerable) {
+    ship.invulnTimer -= dt;
+    ship.flickerTimer += dt;
+    ship.visible = Math.floor(ship.flickerTimer / 80) % 2 === 0;
+    if (ship.invulnTimer <= 0) {
+      ship.invulnerable = false;
+      ship.visible = true;
+    }
+  }
+}
+
+function drawShip() {
+  if (!ship || !ship.visible) return;
+
+  ctx.save();
+  ctx.translate(ship.x, ship.y);
+  ctx.rotate(ship.angle);
+
+  // Ship body — triangle
+  ctx.beginPath();
+  ctx.moveTo(SHIP_RADIUS, 0);
+  ctx.lineTo(-SHIP_RADIUS * 0.7, -SHIP_RADIUS * 0.6);
+  ctx.lineTo(-SHIP_RADIUS * 0.4, 0);
+  ctx.lineTo(-SHIP_RADIUS * 0.7, SHIP_RADIUS * 0.6);
+  ctx.closePath();
+  ctx.strokeStyle = COLOR_SHIP;
+  ctx.lineWidth = 2;
+  ctx.shadowColor = COLOR_SHIP;
+  ctx.shadowBlur = 10;
+  ctx.stroke();
+  ctx.shadowBlur = 0;
+
+  // Thrust flame
+  if (ship.thrusting) {
+    ctx.beginPath();
+    ctx.moveTo(-SHIP_RADIUS * 0.5, -SHIP_RADIUS * 0.25);
+    ctx.lineTo(-SHIP_RADIUS * (0.8 + Math.random() * 0.5), 0);
+    ctx.lineTo(-SHIP_RADIUS * 0.5, SHIP_RADIUS * 0.25);
+    ctx.strokeStyle = COLOR_THRUST;
+    ctx.lineWidth = 1.5;
+    ctx.shadowColor = COLOR_THRUST;
+    ctx.shadowBlur = 8;
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+  }
+
+  ctx.restore();
+}
+
+// ── Bullets ─────────────────────────────────────────────────────────────────
+function fireBullet() {
+  if (!ship || bullets.length >= MAX_BULLETS) return;
+  const now = performance.now();
+  if (now - lastFireTime < FIRE_COOLDOWN) return;
+  lastFireTime = now;
+
+  bullets.push({
+    x: ship.x + Math.cos(ship.angle) * SHIP_RADIUS,
+    y: ship.y + Math.sin(ship.angle) * SHIP_RADIUS,
+    vx: Math.cos(ship.angle) * BULLET_SPEED + ship.vx * 0.3,
+    vy: Math.sin(ship.angle) * BULLET_SPEED + ship.vy * 0.3,
+    life: BULLET_LIFE,
+  });
+}
+
+function updateBullets(dt) {
+  const dtFactor = dt * 60 / 1000;
+  for (let i = bullets.length - 1; i >= 0; i--) {
+    const b = bullets[i];
+    b.x += b.vx * dtFactor;
+    b.y += b.vy * dtFactor;
+    b.life -= dtFactor;
+
+    const w = wrap(b.x, b.y);
+    b.x = w.x;
+    b.y = w.y;
+
+    if (b.life <= 0) bullets.splice(i, 1);
+  }
+}
+
+function drawBullets() {
+  ctx.fillStyle = COLOR_BULLET;
+  ctx.shadowColor = COLOR_BULLET;
+  ctx.shadowBlur = 8;
+  for (const b of bullets) {
+    ctx.beginPath();
+    ctx.arc(b.x, b.y, BULLET_RADIUS, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.shadowBlur = 0;
+}
+
+// ── Asteroids ───────────────────────────────────────────────────────────────
+function createAsteroid(size, x, y, vx, vy) {
+  const def = ASTEROID_SIZES[size];
+  return {
+    x, y,
+    vx: vx ?? rand(-def.speed, def.speed),
+    vy: vy ?? rand(-def.speed, def.speed),
+    size,
+    radius: def.radius,
+    shape: generateAsteroidShape(def.radius),
+    rotAngle: rand(0, Math.PI * 2),
+    rotSpeed: rand(-0.02, 0.02),
+  };
+}
+
+function spawnWaveAsteroids() {
+  wave++;
+  const count = wave + 3;
+  for (let i = 0; i < count; i++) {
+    // Spawn from edges
+    let x, y;
+    if (Math.random() < 0.5) {
+      x = Math.random() < 0.5 ? -30 : CANVAS_W + 30;
+      y = rand(0, CANVAS_H);
+    } else {
+      x = rand(0, CANVAS_W);
+      y = Math.random() < 0.5 ? -30 : CANVAS_H + 30;
+    }
+    const speed = ASTEROID_SIZES.large.speed;
+    const angle = rand(0, Math.PI * 2);
+    asteroids.push(createAsteroid('large', x, y, Math.cos(angle) * speed, Math.sin(angle) * speed));
+  }
+  waveEl.textContent = wave;
+}
+
+function updateAsteroids(dt) {
+  const dtFactor = dt * 60 / 1000;
+  for (const a of asteroids) {
+    a.x += a.vx * dtFactor;
+    a.y += a.vy * dtFactor;
+    a.rotAngle += a.rotSpeed * dtFactor;
+    const w = wrap(a.x, a.y);
+    a.x = w.x;
+    a.y = w.y;
+  }
+}
+
+function drawAsteroids() {
+  for (const a of asteroids) {
+    ctx.save();
+    ctx.translate(a.x, a.y);
+    ctx.rotate(a.rotAngle);
+    ctx.beginPath();
+    ctx.moveTo(a.shape[0].x, a.shape[0].y);
+    for (let i = 1; i < a.shape.length; i++) {
+      ctx.lineTo(a.shape[i].x, a.shape[i].y);
+    }
+    ctx.closePath();
+    ctx.strokeStyle = COLOR_ASTEROID;
+    ctx.lineWidth = 1.5;
+    ctx.shadowColor = COLOR_ASTEROID_GLOW;
+    ctx.shadowBlur = 6;
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+    ctx.restore();
+  }
+}
+
+function destroyAsteroid(index) {
+  const a = asteroids[index];
+  const def = ASTEROID_SIZES[a.size];
+
+  // Spawn particles
+  spawnParticles(a.x, a.y, Math.floor(a.radius / 3) + 4);
+
+  // Add score
+  score += def.points;
+  scoreEl.textContent = score;
+
+  // Split into children
+  if (def.children) {
+    const childDef = ASTEROID_SIZES[def.children];
+    for (let i = 0; i < 2; i++) {
+      const angle = rand(0, Math.PI * 2);
+      asteroids.push(createAsteroid(
+        def.children,
+        a.x + rand(-5, 5),
+        a.y + rand(-5, 5),
+        Math.cos(angle) * childDef.speed,
+        Math.sin(angle) * childDef.speed
+      ));
+    }
+  }
+
+  asteroids.splice(index, 1);
+}
+
+// ── Particles ───────────────────────────────────────────────────────────────
+function spawnParticles(x, y, count) {
+  for (let i = 0; i < count; i++) {
+    const angle = rand(0, Math.PI * 2);
+    const speed = rand(1, 4);
+    particles.push({
+      x, y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed,
+      life: PARTICLE_LIFE,
+      maxLife: PARTICLE_LIFE,
+    });
+  }
+}
+
+function updateParticles(dt) {
+  const dtFactor = dt * 60 / 1000;
+  for (let i = particles.length - 1; i >= 0; i--) {
+    const p = particles[i];
+    p.x += p.vx * dtFactor;
+    p.y += p.vy * dtFactor;
+    p.life -= dtFactor;
+    if (p.life <= 0) particles.splice(i, 1);
+  }
+}
+
+function drawParticles() {
+  for (const p of particles) {
+    const alpha = p.life / p.maxLife;
+    ctx.fillStyle = `rgba(51,255,136,${alpha})`;
+    ctx.shadowColor = COLOR_PARTICLE;
+    ctx.shadowBlur = 4;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 1.5, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.shadowBlur = 0;
+}
+
+// ── UFO ─────────────────────────────────────────────────────────────────────
+function spawnUfo() {
+  const fromLeft = Math.random() < 0.5;
+  ufo = {
+    x: fromLeft ? -UFO_RADIUS : CANVAS_W + UFO_RADIUS,
+    y: rand(50, CANVAS_H - 50),
+    vx: fromLeft ? UFO_SPEED : -UFO_SPEED,
+    vy: rand(-0.5, 0.5),
+    lastFireTime: performance.now(),
+  };
+}
+
+function updateUfo(dt) {
+  if (!ufo) {
+    // Timer for next UFO
+    ufoTimer += dt;
+    if (ufoTimer >= nextUfoTime && asteroids.length > 0) {
+      spawnUfo();
+      ufoTimer = 0;
+      nextUfoTime = rand(UFO_INTERVAL_MIN, UFO_INTERVAL_MAX);
+    }
+    return;
+  }
+
+  const dtFactor = dt * 60 / 1000;
+  ufo.x += ufo.vx * dtFactor;
+  ufo.y += ufo.vy * dtFactor;
+
+  // Slight vertical wobble
+  ufo.vy += rand(-0.05, 0.05) * dtFactor;
+  ufo.vy = Math.max(-1, Math.min(1, ufo.vy));
+
+  // Keep in vertical bounds
+  if (ufo.y < 30) ufo.vy = Math.abs(ufo.vy);
+  if (ufo.y > CANVAS_H - 30) ufo.vy = -Math.abs(ufo.vy);
+
+  // Remove if offscreen
+  if (ufo.x < -60 || ufo.x > CANVAS_W + 60) {
+    ufo = null;
+    return;
+  }
+
+  // Fire at player
+  if (ship) {
+    const now = performance.now();
+    if (now - ufo.lastFireTime > UFO_FIRE_RATE) {
+      ufo.lastFireTime = now;
+      const angle = Math.atan2(ship.y - ufo.y, ship.x - ufo.x) + rand(-0.3, 0.3);
+      ufoBullets.push({
+        x: ufo.x,
+        y: ufo.y,
+        vx: Math.cos(angle) * UFO_BULLET_SPEED,
+        vy: Math.sin(angle) * UFO_BULLET_SPEED,
+        life: 80,
+      });
+    }
+  }
+}
+
+function updateUfoBullets(dt) {
+  const dtFactor = dt * 60 / 1000;
+  for (let i = ufoBullets.length - 1; i >= 0; i--) {
+    const b = ufoBullets[i];
+    b.x += b.vx * dtFactor;
+    b.y += b.vy * dtFactor;
+    b.life -= dtFactor;
+    if (b.life <= 0 || b.x < -10 || b.x > CANVAS_W + 10 || b.y < -10 || b.y > CANVAS_H + 10) {
+      ufoBullets.splice(i, 1);
+    }
+  }
+}
+
+function drawUfo() {
+  if (!ufo) return;
+
+  ctx.save();
+  ctx.translate(ufo.x, ufo.y);
+
+  // UFO body — classic saucer shape
+  ctx.beginPath();
+  ctx.ellipse(0, 0, UFO_RADIUS, UFO_RADIUS * 0.4, 0, 0, Math.PI * 2);
+  ctx.strokeStyle = COLOR_UFO;
+  ctx.lineWidth = 2;
+  ctx.shadowColor = COLOR_UFO;
+  ctx.shadowBlur = 10;
+  ctx.stroke();
+
+  // Dome
+  ctx.beginPath();
+  ctx.ellipse(0, -UFO_RADIUS * 0.2, UFO_RADIUS * 0.5, UFO_RADIUS * 0.35, 0, Math.PI, 0);
+  ctx.stroke();
+  ctx.shadowBlur = 0;
+
+  ctx.restore();
+}
+
+function drawUfoBullets() {
+  ctx.fillStyle = COLOR_UFO_BULLET;
+  ctx.shadowColor = COLOR_UFO_BULLET;
+  ctx.shadowBlur = 6;
+  for (const b of ufoBullets) {
+    ctx.beginPath();
+    ctx.arc(b.x, b.y, 3, 0, Math.PI * 2);
+    ctx.fill();
+  }
+  ctx.shadowBlur = 0;
+}
+
+// ── Collisions ──────────────────────────────────────────────────────────────
+function checkCollisions() {
+  // Bullets vs Asteroids
+  for (let bi = bullets.length - 1; bi >= 0; bi--) {
+    const b = bullets[bi];
+    for (let ai = asteroids.length - 1; ai >= 0; ai--) {
+      const a = asteroids[ai];
+      if (dist(b.x, b.y, a.x, a.y) < a.radius) {
+        bullets.splice(bi, 1);
+        destroyAsteroid(ai);
+        break;
+      }
+    }
+  }
+
+  // Bullets vs UFO
+  if (ufo) {
+    for (let bi = bullets.length - 1; bi >= 0; bi--) {
+      const b = bullets[bi];
+      if (dist(b.x, b.y, ufo.x, ufo.y) < UFO_RADIUS) {
+        bullets.splice(bi, 1);
+        score += UFO_POINTS;
+        scoreEl.textContent = score;
+        spawnParticles(ufo.x, ufo.y, 15);
+        ufo = null;
+        break;
+      }
+    }
+  }
+
+  // Ship vs Asteroids
+  if (ship && !ship.invulnerable) {
+    for (let ai = asteroids.length - 1; ai >= 0; ai--) {
+      const a = asteroids[ai];
+      if (dist(ship.x, ship.y, a.x, a.y) < a.radius + SHIP_RADIUS * 0.6) {
+        destroyAsteroid(ai);
+        killShip();
+        return;
+      }
+    }
+  }
+
+  // Ship vs UFO
+  if (ship && !ship.invulnerable && ufo) {
+    if (dist(ship.x, ship.y, ufo.x, ufo.y) < UFO_RADIUS + SHIP_RADIUS * 0.6) {
+      spawnParticles(ufo.x, ufo.y, 15);
+      ufo = null;
+      killShip();
+      return;
+    }
+  }
+
+  // Ship vs UFO bullets
+  if (ship && !ship.invulnerable) {
+    for (let i = ufoBullets.length - 1; i >= 0; i--) {
+      const b = ufoBullets[i];
+      if (dist(ship.x, ship.y, b.x, b.y) < SHIP_RADIUS * 0.6 + 3) {
+        ufoBullets.splice(i, 1);
+        killShip();
+        return;
+      }
+    }
+  }
+}
+
+function killShip() {
+  spawnParticles(ship.x, ship.y, 20);
+  lives--;
+  updateLivesDisplay();
+
+  if (lives <= 0) {
+    ship = null;
+    endGame();
+  } else {
+    // Respawn at center with invulnerability
+    ship = createShip();
+  }
+}
+
+function updateLivesDisplay() {
+  let stars = '';
+  for (let i = 0; i < lives; i++) stars += '\u2733';
+  livesEl.textContent = stars || '---';
+}
+
+// ── Game flow ───────────────────────────────────────────────────────────────
+function startGame() {
+  score = 0;
+  lives = MAX_LIVES;
+  wave = 0;
+  bullets = [];
+  asteroids = [];
+  particles = [];
+  ufo = null;
+  ufoBullets = [];
+  ufoTimer = 0;
+  nextUfoTime = rand(UFO_INTERVAL_MIN, UFO_INTERVAL_MAX);
+  lastFireTime = 0;
+  gameOver = false;
+
+  scoreEl.textContent = '0';
+  updateLivesDisplay();
+  waveEl.textContent = '1';
+
+  ship = createShip();
+  spawnWaveAsteroids();
+
+  overlay.style.display = 'none';
+  running = true;
+  lastTime = performance.now();
+  requestAnimationFrame(gameLoop);
+}
+
+function endGame() {
+  gameOver = true;
+  running = false;
+
+  // Show game over overlay
+  overlay.querySelector('h2').textContent = 'GAME OVER';
+  overlay.querySelector('p').textContent = 'Final Score: ' + score.toLocaleString();
+  startBtn.textContent = 'PLAY AGAIN';
+  overlay.style.display = 'flex';
+
+  // Submit score
+  submitScore();
+}
+
+async function submitScore() {
+  try {
+    const res = await api.post('/api/scores/asteroids', { score });
+    if (res && res.ok) {
+      const data = await res.json();
+      const rankInfo = document.createElement('p');
+      rankInfo.style.cssText = 'font-size:0.9rem;color:#33ff88;text-shadow:0 0 6px #33ff88;';
+      rankInfo.textContent = 'Rank: #' + data.rank;
+      overlay.querySelector('p').after(rankInfo);
+    }
+  } catch (err) {
+    console.error('Score submission failed:', err);
+  }
+  if (typeof window.loadMiniLeaderboard === 'function') {
+    window.loadMiniLeaderboard();
+  }
+}
+
+// ── Game loop ───────────────────────────────────────────────────────────────
+function gameLoop(timestamp) {
+  if (!running) return;
+
+  const dt = Math.min(timestamp - lastTime, 50); // cap at 50ms to prevent spiral
+  lastTime = timestamp;
+
+  update(dt);
+  draw();
+
+  requestAnimationFrame(gameLoop);
+}
+
+function update(dt) {
+  updateShip(dt);
+  updateBullets(dt);
+  updateAsteroids(dt);
+  updateParticles(dt);
+  updateUfo(dt);
+  updateUfoBullets(dt);
+  checkCollisions();
+
+  // Fire continuously while key held
+  if (keys[' '] || keys['Space']) fireBullet();
+
+  // Check if wave cleared
+  if (asteroids.length === 0 && !gameOver) {
+    spawnWaveAsteroids();
+  }
+}
+
+function draw() {
+  // Clear
+  ctx.fillStyle = '#000';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Faint starfield (static)
+  drawStars();
+
+  drawAsteroids();
+  drawBullets();
+  drawUfo();
+  drawUfoBullets();
+  drawParticles();
+  drawShip();
+}
+
+// ── Static starfield ────────────────────────────────────────────────────────
+const stars = [];
+for (let i = 0; i < 80; i++) {
+  stars.push({
+    x: Math.random() * CANVAS_W,
+    y: Math.random() * CANVAS_H,
+    r: Math.random() * 1.2 + 0.3,
+    alpha: Math.random() * 0.5 + 0.2,
+  });
+}
+
+function drawStars() {
+  for (const s of stars) {
+    ctx.fillStyle = `rgba(255,255,255,${s.alpha})`;
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, s.r, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+
+// ── Input ───────────────────────────────────────────────────────────────────
+document.addEventListener('keydown', (e) => {
+  keys[e.key] = true;
+  if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+    e.preventDefault();
+  }
+});
+
+document.addEventListener('keyup', (e) => {
+  keys[e.key] = false;
+});
+
+// Start button
+startBtn.addEventListener('click', () => {
+  // Clean up any leftover rank info from previous game
+  const extra = overlay.querySelectorAll('p');
+  if (extra.length > 1) {
+    for (let i = 1; i < extra.length; i++) extra[i].remove();
+  }
+  // Restore overlay text
+  overlay.querySelector('h2').textContent = 'VOID DRIFTER';
+  overlay.querySelector('p').innerHTML =
+    'Left/Right or A/D \u2014 Rotate<br>' +
+    'Up or W \u2014 Thrust<br>' +
+    'Space \u2014 Fire<br>' +
+    'Destroy asteroids. Survive the void.';
+  startBtn.textContent = 'START GAME';
+  startGame();
+});

--- a/public/games/asteroids/index.html
+++ b/public/games/asteroids/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Void Drifter — Retro Arcade</title>
+  <link rel="stylesheet" href="/css/main.css" />
+  <style>
+    .game-layout {
+      display: flex;
+      gap: 24px;
+      justify-content: center;
+      align-items: flex-start;
+      padding: 20px;
+      flex-wrap: wrap;
+    }
+    .game-main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      user-select: none;
+      max-width: 100%;
+      overflow: hidden;
+    }
+    .game-main h1 {
+      font-size: 1.4rem;
+      letter-spacing: 0.2em;
+      text-shadow: 0 0 10px #33ff88, 0 0 20px #33ff88;
+      margin-bottom: 0.4rem;
+      color: #33ff88;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+    }
+    #hud {
+      display: flex;
+      gap: 1.5rem;
+      font-size: 0.9rem;
+      margin-bottom: 0.4rem;
+      text-shadow: 0 0 6px #0ff;
+      color: #0ff;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    #canvas-wrapper { position: relative; max-width: 100%; }
+    canvas {
+      display: block;
+      border: 2px solid #33ff88;
+      box-shadow: 0 0 20px #33ff88, 0 0 40px #009944;
+      max-width: 100%;
+      height: auto;
+    }
+    #overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.82);
+      color: #33ff88;
+      gap: 0.8rem;
+    }
+    #overlay h2 {
+      font-size: 1.8rem;
+      text-shadow: 0 0 10px #33ff88;
+      letter-spacing: 0.2em;
+      font-family: var(--font-pixel);
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+      max-width: 90%;
+    }
+    #overlay p {
+      font-size: 0.95rem;
+      opacity: 0.85;
+      text-align: center;
+      max-width: 380px;
+      line-height: 1.6;
+    }
+    #overlay button {
+      background: transparent;
+      border: 2px solid #33ff88;
+      color: #33ff88;
+      font-family: inherit;
+      font-size: 1.1rem;
+      padding: 0.5rem 2rem;
+      cursor: pointer;
+      text-shadow: 0 0 6px #33ff88;
+      box-shadow: 0 0 10px #33ff88;
+      letter-spacing: 0.1em;
+    }
+    #overlay button:hover { background: rgba(51,255,136,0.1); }
+
+    /* Leaderboard panel */
+    .game-leaderboard {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 16px;
+      min-width: 220px;
+      max-width: 280px;
+    }
+    .game-leaderboard h3 {
+      font-family: var(--font-pixel);
+      font-size: 0.55rem;
+      color: var(--neon-gold);
+      text-shadow: 0 0 6px rgba(255,215,0,0.4);
+      margin-bottom: 12px;
+      text-align: center;
+    }
+    .lb-list { list-style: none; font-size: 0.8rem; }
+    .lb-list li {
+      display: flex;
+      justify-content: space-between;
+      padding: 4px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .lb-list li:last-child { border-bottom: none; }
+    .lb-rank { color: var(--neon-cyan); min-width: 28px; }
+    .lb-name { flex: 1; margin: 0 8px; }
+    .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
+
+    @media (max-width: 900px) {
+      .game-layout { flex-direction: column; align-items: center; }
+      .game-leaderboard { max-width: 100%; min-width: 280px; }
+    }
+    @media (max-width: 480px) {
+      #hud {
+        font-size: 0.7rem;
+        gap: 0.4rem 0.8rem;
+      }
+      #overlay {
+        overflow-y: auto;
+        gap: 0.4rem;
+        padding: 0.5rem;
+      }
+      #overlay h2 {
+        font-size: 1.1rem;
+        letter-spacing: 0.1em;
+      }
+      #overlay p {
+        font-size: 0.7rem;
+        max-width: 95%;
+        line-height: 1.3;
+      }
+      #overlay button {
+        font-size: 0.85rem;
+        padding: 0.35rem 1.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <a href="/" class="navbar-brand">RETRO ARCADE</a>
+    <div class="navbar-links">
+      <a href="/leaderboard.html">Leaderboard</a>
+      <span id="nav-auth-links" style="display:flex;gap:20px;">
+        <a href="/auth/login.html">Login</a>
+        <a href="/auth/register.html">Register</a>
+      </span>
+      <span id="nav-user-info" style="display:none;align-items:center;gap:12px;">
+        <span class="navbar-user" id="nav-username"></span>
+        <a href="#" id="nav-logout-btn">Logout</a>
+      </span>
+    </div>
+  </nav>
+
+  <div class="game-layout">
+    <div class="game-main">
+      <h1>VOID DRIFTER</h1>
+      <div id="hud">
+        <span>SCORE: <span id="score">0</span></span>
+        <span>LIVES: <span id="lives">&#9733;&#9733;&#9733;</span></span>
+        <span>WAVE: <span id="wave">1</span></span>
+      </div>
+      <div id="canvas-wrapper">
+        <canvas id="canvas" width="700" height="520"></canvas>
+        <div id="overlay">
+          <h2>VOID DRIFTER</h2>
+          <p>
+            Left/Right or A/D — Rotate<br>
+            Up or W — Thrust<br>
+            Space — Fire<br>
+            Destroy asteroids. Survive the void.
+          </p>
+          <button id="start-btn">START GAME</button>
+        </div>
+      </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="touch-controls-row">
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowUp" style="width:64px;height:64px;font-size:1.6rem;">&#9650;</button>
+          <button class="touch-btn-fire" id="fire-btn">FIRE</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+        </div>
+        <div class="touch-hint">ROTATE &bull; THRUST &bull; FIRE</div>
+      </div>
+    </div>
+
+    <div class="game-leaderboard">
+      <h3>TOP SCORES</h3>
+      <ul class="lb-list" id="lb-list">
+        <li class="lb-empty">Loading...</li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="/js/api.js"></script>
+  <script>
+    // Touch controls — movement buttons
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      let interval = null;
+      const startMove = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        interval = setInterval(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        }, 80);
+      };
+      const stopMove = (e) => {
+        e.preventDefault();
+        clearInterval(interval);
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', startMove, { passive: false });
+      btn.addEventListener('touchend', stopMove, { passive: false });
+      btn.addEventListener('touchcancel', stopMove, { passive: false });
+    });
+
+    // Fire button
+    const fireBtn = document.getElementById('fire-btn');
+    if (fireBtn) {
+      fireBtn.addEventListener('touchstart', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+      fireBtn.addEventListener('touchend', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+      fireBtn.addEventListener('touchcancel', (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: ' ', code: 'Space', bubbles: true }));
+      }, { passive: false });
+    }
+
+    async function loadMiniLeaderboard() {
+      const list = document.getElementById('lb-list');
+      if (!list) return;
+      try {
+        const res = await api.get('/api/scores/asteroids');
+        if (!res || !res.ok) throw new Error('fetch failed');
+        const scores = await res.json();
+        const user = await api.getUser();
+
+        if (scores.length === 0) {
+          list.innerHTML = '<li class="lb-empty">No scores yet</li>';
+          return;
+        }
+
+        list.innerHTML = '';
+        for (const s of scores) {
+          const isSelf = user && s.username === user.username;
+          const li = document.createElement('li');
+          if (isSelf) li.style.color = 'var(--neon-gold)';
+          const rankSpan = document.createElement('span');
+          rankSpan.className = 'lb-rank';
+          rankSpan.textContent = '#' + s.rank;
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'lb-name';
+          nameSpan.textContent = isSelf ? s.username + ' (YOU)' : s.username;
+          const scoreSpan = document.createElement('span');
+          scoreSpan.className = 'lb-score';
+          scoreSpan.textContent = s.score.toLocaleString();
+          li.append(rankSpan, nameSpan, scoreSpan);
+          list.appendChild(li);
+        }
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
+        list.innerHTML = '<li class="lb-empty">Failed to load</li>';
+      }
+    }
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
+  </script>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -96,6 +96,14 @@
         <div class="card-top-score" id="top-breakout">TOP: ---</div>
         <a href="/games/breakout/" class="btn btn-pink">PLAY</a>
       </div>
+
+      <!-- Void Drifter -->
+      <div class="card">
+        <h3>VOID DRIFTER</h3>
+        <p>Asteroids with vector wireframes, screen wrapping, and UFO encounters. Drift through the void.</p>
+        <div class="card-top-score" id="top-asteroids">TOP: ---</div>
+        <a href="/games/asteroids/" class="btn" style="border-color:#33ff88;color:#33ff88;box-shadow:0 0 8px rgba(51,255,136,0.2);">PLAY</a>
+      </div>
     </div>
 
     <div style="text-align:center;margin:30px 0;">
@@ -120,6 +128,7 @@
         { id: 'pong', el: 'top-pong' },
         { id: 'tetris', el: 'top-tetris' },
         { id: 'breakout', el: 'top-breakout' },
+        { id: 'asteroids', el: 'top-asteroids' },
       ];
 
       for (const game of games) {

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -50,6 +50,7 @@
               <th>Photon Paddle</th>
               <th>Neon Stack</th>
               <th>Brick Blitz</th>
+              <th>Void Drifter</th>
             </tr>
           </thead>
           <tbody id="overall-tbody"></tbody>
@@ -68,6 +69,7 @@
         <option value="pong">Photon Paddle</option>
         <option value="tetris">Neon Stack</option>
         <option value="breakout">Brick Blitz</option>
+        <option value="asteroids">Void Drifter</option>
       </select>
       <div class="loading" id="game-loading">LOADING...</div>
       <div class="table-wrap" id="game-table-wrap" style="display:none;">
@@ -110,6 +112,7 @@
       'pong': 'Photon Paddle',
       'tetris': 'Neon Stack',
       'breakout': 'Brick Blitz',
+      'asteroids': 'Void Drifter',
     };
 
     // ---- Tab switching ----
@@ -166,6 +169,7 @@
           const pongPts = entry.breakdown?.pong?.points ?? 0;
           const tetrisPts = entry.breakdown?.['tetris']?.points ?? 0;
           const breakoutPts = entry.breakdown?.breakout?.points ?? 0;
+          const asteroidsPts = entry.breakdown?.['asteroids']?.points ?? 0;
 
           const rankTd = document.createElement('td');
           rankTd.className = rankClass(entry.rank);
@@ -188,7 +192,9 @@
           tetrisTd.textContent = tetrisPts;
           const breakoutTd = document.createElement('td');
           breakoutTd.textContent = breakoutPts;
-          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd, pongTd, tetrisTd, breakoutTd);
+          const asteroidsTd = document.createElement('td');
+          asteroidsTd.textContent = asteroidsPts;
+          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd, pongTd, tetrisTd, breakoutTd, asteroidsTd);
           tbody.appendChild(tr);
         }
 

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { pointsForPosition } from '../utils/f1-points.js';
 
-const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris', 'breakout'];
+const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris', 'breakout', 'asteroids'];
 
 /**
  * Computes per-game rankings (best score per user) for a given game.

--- a/src/routes/scores.js
+++ b/src/routes/scores.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
 
-const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris', 'breakout'];
+const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong', 'tetris', 'breakout', 'asteroids'];
 const MAX_SCORE = 999999;
 const RATE_LIMIT_WINDOW_MS = 3 * 1000; // 3 seconds — prevents double-submit without blocking back-to-back games
 


### PR DESCRIPTION
## Summary
- Adds complete playable Asteroids game (VOID DRIFTER) at /games/asteroids/
- Vector wireframe rendering with neon green glow (#33ff88)
- Ship rotation, thrust with friction, screen wrapping for all entities
- Asteroids split on hit (large -> 2 medium -> 2 small -> destroyed), wave progression
- UFO enemy that flies horizontally and shoots at player (200pts)
- Particle effects on destruction, invulnerability on respawn
- Score submission and mini-leaderboard panel
- Mobile touch controls (rotate left/right, thrust, fire)
- Added to homepage card grid, leaderboard (overall + per-game), VALID_GAMES, GAMES arrays

Closes #68

## Test plan
- [ ] `curl -s http://localhost:3000/games/asteroids/ | grep -q "VOID DRIFTER"`
- [ ] Ship rotates with Left/Right or A/D, thrusts with Up/W
- [ ] Ship, bullets, and asteroids wrap at screen edges
- [ ] Asteroids split into smaller sizes on hit, waves progress
- [ ] UFO appears periodically, shoots at player
- [ ] Lives system: 3 lives, respawn with invulnerability flicker
- [ ] Score submits on game over, appears in mini-leaderboard
- [ ] Homepage shows Void Drifter card with green styling
- [ ] Leaderboard overall table has Void Drifter column
- [ ] Per-game selector includes Void Drifter option

🤖 Generated with [Claude Code](https://claude.com/claude-code)