### PR TITLE
feat: add Pong game — Photon Paddle (#69)

### DIFF
--- a/public/games/pong/game.js
+++ b/public/games/pong/game.js
@@ -1,0 +1,409 @@
+/**
+ * Photon Paddle — Pong vs CPU
+ * - Player paddle (left, cyan) vs CPU paddle (right, pink)
+ * - Ball with particle trail, angle-based paddle reflection
+ * - Ball speed increases after each rally, resets on score
+ * - Score to 10, rally count submitted to leaderboard
+ * - Three difficulty modes: Easy, Normal, Hard
+ */
+
+const CANVAS_W = 700;
+const CANVAS_H = 520;
+
+// ── Paddle constants ────────────────────────────────────────────────────────
+const PADDLE_W = 10;
+const PADDLE_H = 80;
+const PADDLE_MARGIN = 20;
+const PADDLE_SPEED = 6;
+
+// ── Ball constants ──────────────────────────────────────────────────────────
+const BALL_RADIUS = 8;
+const BALL_BASE_SPEED = 5;
+const BALL_SPEED_INCREMENT = 0.3;
+const BALL_MAX_SPEED = 12;
+
+// ── Match constants ─────────────────────────────────────────────────────────
+const WIN_SCORE = 10;
+
+// ── Difficulty presets ──────────────────────────────────────────────────────
+const DIFFICULTY = {
+  easy:   { cpuSpeed: 2.5, reactionZone: 0.4 },
+  normal: { cpuSpeed: 4.0, reactionZone: 0.6 },
+  hard:   { cpuSpeed: 5.5, reactionZone: 0.85 },
+};
+
+// ── Colors ──────────────────────────────────────────────────────────────────
+const COLOR_BALL = '#ffee00';
+const COLOR_PLAYER = '#0ff';
+const COLOR_CPU = '#f0f';
+const COLOR_CENTER_LINE = 'rgba(255,238,0,0.15)';
+const COLOR_BG = '#0a0a0a';
+
+// ── Canvas setup ────────────────────────────────────────────────────────────
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+// ── DOM refs ────────────────────────────────────────────────────────────────
+const playerScoreEl = document.getElementById('player-score');
+const cpuScoreEl = document.getElementById('cpu-score');
+const ralliesEl = document.getElementById('rallies');
+const overlay = document.getElementById('overlay');
+const startBtn = document.getElementById('start-btn');
+const gameOverOverlay = document.getElementById('game-over-overlay');
+const gameOverTitle = document.getElementById('game-over-title');
+const gameOverInfo = document.getElementById('game-over-info');
+const restartBtn = document.getElementById('restart-btn');
+
+// ── Difficulty selector ─────────────────────────────────────────────────────
+let selectedDifficulty = 'normal';
+const diffBtns = document.querySelectorAll('.diff-btn');
+diffBtns.forEach(btn => {
+  btn.addEventListener('click', () => {
+    diffBtns.forEach(b => b.classList.remove('active'));
+    btn.classList.add('active');
+    selectedDifficulty = btn.dataset.diff;
+  });
+});
+
+// ── Game state ──────────────────────────────────────────────────────────────
+let running = false;
+let scoreSubmitted = false;
+let lastTime = 0;
+
+let playerY = 0;
+let cpuY = 0;
+let playerScore = 0;
+let cpuScore = 0;
+let totalRallies = 0;
+let currentRally = 0;
+
+let ballX = 0;
+let ballY = 0;
+let ballVX = 0;
+let ballVY = 0;
+let ballSpeed = BALL_BASE_SPEED;
+
+// Particle trail
+const particles = [];
+const MAX_PARTICLES = 40;
+
+// Input state
+const keys = {};
+
+// ── Input handling ──────────────────────────────────────────────────────────
+document.addEventListener('keydown', (e) => {
+  keys[e.key] = true;
+  if (['ArrowUp', 'ArrowDown', 'w', 's', ' '].includes(e.key)) {
+    e.preventDefault();
+  }
+});
+document.addEventListener('keyup', (e) => {
+  keys[e.key] = false;
+});
+
+// ── Helper: reset ball to center ────────────────────────────────────────────
+function resetBall(direction) {
+  ballX = CANVAS_W / 2;
+  ballY = CANVAS_H / 2;
+  ballSpeed = BALL_BASE_SPEED;
+  currentRally = 0;
+
+  // Launch at a random angle between -30 and +30 degrees
+  const angle = (Math.random() * 60 - 30) * (Math.PI / 180);
+  ballVX = Math.cos(angle) * ballSpeed * direction;
+  ballVY = Math.sin(angle) * ballSpeed;
+
+  // Clear particles on reset
+  particles.length = 0;
+}
+
+// ── Helper: spawn particle ──────────────────────────────────────────────────
+function spawnParticle(x, y) {
+  if (particles.length >= MAX_PARTICLES) {
+    particles.shift();
+  }
+  particles.push({ x, y, life: 1.0 });
+}
+
+// ── Start game ──────────────────────────────────────────────────────────────
+function startGame() {
+  playerScore = 0;
+  cpuScore = 0;
+  totalRallies = 0;
+  currentRally = 0;
+  scoreSubmitted = false;
+
+  playerY = (CANVAS_H - PADDLE_H) / 2;
+  cpuY = (CANVAS_H - PADDLE_H) / 2;
+
+  resetBall(1);
+
+  updateHUD();
+  overlay.style.display = 'none';
+  gameOverOverlay.style.display = 'none';
+  running = true;
+  lastTime = performance.now();
+  requestAnimationFrame(gameLoop);
+}
+
+// ── Update HUD ──────────────────────────────────────────────────────────────
+function updateHUD() {
+  playerScoreEl.textContent = playerScore;
+  cpuScoreEl.textContent = cpuScore;
+  ralliesEl.textContent = totalRallies;
+}
+
+// ── CPU AI ──────────────────────────────────────────────────────────────────
+function updateCPU(dt) {
+  const diff = DIFFICULTY[selectedDifficulty];
+  const cpuCenter = cpuY + PADDLE_H / 2;
+
+  // Only react when ball is in the CPU's reaction zone (right portion of field)
+  const reactionX = CANVAS_W * (1 - diff.reactionZone);
+  if (ballVX > 0 && ballX > reactionX) {
+    const targetY = ballY;
+    const delta = targetY - cpuCenter;
+    const maxMove = diff.cpuSpeed * dt * 60;
+
+    if (Math.abs(delta) > 2) {
+      cpuY += Math.sign(delta) * Math.min(Math.abs(delta), maxMove);
+    }
+  } else {
+    // Drift toward center when ball heading away
+    const centerDelta = (CANVAS_H / 2) - cpuCenter;
+    const driftSpeed = diff.cpuSpeed * 0.3 * dt * 60;
+    if (Math.abs(centerDelta) > 2) {
+      cpuY += Math.sign(centerDelta) * Math.min(Math.abs(centerDelta), driftSpeed);
+    }
+  }
+
+  // Clamp
+  cpuY = Math.max(0, Math.min(CANVAS_H - PADDLE_H, cpuY));
+}
+
+// ── Ball-paddle collision ───────────────────────────────────────────────────
+function checkPaddleCollision() {
+  // Player paddle (left side)
+  const playerPaddleRight = PADDLE_MARGIN + PADDLE_W;
+  if (
+    ballVX < 0 &&
+    ballX - BALL_RADIUS <= playerPaddleRight &&
+    ballX - BALL_RADIUS >= PADDLE_MARGIN - BALL_RADIUS &&
+    ballY >= playerY &&
+    ballY <= playerY + PADDLE_H
+  ) {
+    // Where on paddle did it hit? -1 (top) to 1 (bottom)
+    const hitPos = ((ballY - playerY) / PADDLE_H) * 2 - 1;
+    const maxAngle = 60 * (Math.PI / 180);
+    const angle = hitPos * maxAngle;
+
+    ballSpeed = Math.min(ballSpeed + BALL_SPEED_INCREMENT, BALL_MAX_SPEED);
+    ballVX = Math.cos(angle) * ballSpeed;
+    ballVY = Math.sin(angle) * ballSpeed;
+
+    // Push ball out of paddle
+    ballX = playerPaddleRight + BALL_RADIUS;
+
+    currentRally++;
+    totalRallies++;
+    updateHUD();
+    return;
+  }
+
+  // CPU paddle (right side)
+  const cpuPaddleLeft = CANVAS_W - PADDLE_MARGIN - PADDLE_W;
+  if (
+    ballVX > 0 &&
+    ballX + BALL_RADIUS >= cpuPaddleLeft &&
+    ballX + BALL_RADIUS <= cpuPaddleLeft + PADDLE_W + BALL_RADIUS &&
+    ballY >= cpuY &&
+    ballY <= cpuY + PADDLE_H
+  ) {
+    const hitPos = ((ballY - cpuY) / PADDLE_H) * 2 - 1;
+    const maxAngle = 60 * (Math.PI / 180);
+    const angle = hitPos * maxAngle;
+
+    ballSpeed = Math.min(ballSpeed + BALL_SPEED_INCREMENT, BALL_MAX_SPEED);
+    ballVX = -Math.cos(angle) * ballSpeed;
+    ballVY = Math.sin(angle) * ballSpeed;
+
+    // Push ball out of paddle
+    ballX = cpuPaddleLeft - BALL_RADIUS;
+
+    currentRally++;
+    totalRallies++;
+    updateHUD();
+  }
+}
+
+// ── Score check ─────────────────────────────────────────────────────────────
+function checkScore() {
+  // Ball went past left wall -> CPU scores
+  if (ballX - BALL_RADIUS < 0) {
+    cpuScore++;
+    updateHUD();
+    if (cpuScore >= WIN_SCORE) {
+      endMatch(false);
+    } else {
+      resetBall(1); // Launch toward player
+    }
+    return;
+  }
+
+  // Ball went past right wall -> Player scores
+  if (ballX + BALL_RADIUS > CANVAS_W) {
+    playerScore++;
+    updateHUD();
+    if (playerScore >= WIN_SCORE) {
+      endMatch(true);
+    } else {
+      resetBall(-1); // Launch toward CPU
+    }
+  }
+}
+
+// ── End match ───────────────────────────────────────────────────────────────
+async function endMatch(playerWon) {
+  running = false;
+  gameOverTitle.textContent = playerWon ? 'YOU WIN!' : 'YOU LOSE';
+  gameOverTitle.style.color = playerWon ? '#0f0' : '#f44';
+  gameOverInfo.textContent = `Final: ${playerScore} - ${cpuScore} | Total rallies: ${totalRallies}`;
+  gameOverOverlay.style.display = 'flex';
+
+  // Submit score
+  if (!scoreSubmitted) {
+    scoreSubmitted = true;
+    try {
+      await api.post('/api/scores/pong', { score: totalRallies });
+    } catch (err) {
+      console.error('Score submission failed:', err);
+    }
+    if (typeof window.loadMiniLeaderboard === 'function') {
+      window.loadMiniLeaderboard();
+    }
+  }
+}
+
+// ── Main game loop ──────────────────────────────────────────────────────────
+function gameLoop(timestamp) {
+  if (!running) return;
+
+  const dt = Math.min((timestamp - lastTime) / 1000, 0.05); // cap at 50ms
+  lastTime = timestamp;
+
+  update(dt);
+  draw();
+
+  requestAnimationFrame(gameLoop);
+}
+
+// ── Update ──────────────────────────────────────────────────────────────────
+function update(dt) {
+  const scaledDt = dt * 60; // normalize to ~60fps
+
+  // Player paddle movement
+  if (keys['ArrowUp'] || keys['w'] || keys['W']) {
+    playerY -= PADDLE_SPEED * scaledDt;
+  }
+  if (keys['ArrowDown'] || keys['s'] || keys['S']) {
+    playerY += PADDLE_SPEED * scaledDt;
+  }
+  playerY = Math.max(0, Math.min(CANVAS_H - PADDLE_H, playerY));
+
+  // CPU movement
+  updateCPU(dt);
+
+  // Ball movement
+  ballX += ballVX * scaledDt;
+  ballY += ballVY * scaledDt;
+
+  // Top/bottom wall bounce
+  if (ballY - BALL_RADIUS <= 0) {
+    ballY = BALL_RADIUS;
+    ballVY = Math.abs(ballVY);
+  }
+  if (ballY + BALL_RADIUS >= CANVAS_H) {
+    ballY = CANVAS_H - BALL_RADIUS;
+    ballVY = -Math.abs(ballVY);
+  }
+
+  // Paddle collisions
+  checkPaddleCollision();
+
+  // Score check
+  checkScore();
+
+  // Spawn particle trail
+  spawnParticle(ballX, ballY);
+
+  // Decay particles
+  for (let i = particles.length - 1; i >= 0; i--) {
+    particles[i].life -= dt * 3;
+    if (particles[i].life <= 0) {
+      particles.splice(i, 1);
+    }
+  }
+}
+
+// ── Draw ────────────────────────────────────────────────────────────────────
+function draw() {
+  // Background
+  ctx.fillStyle = COLOR_BG;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Center dashed line
+  ctx.setLineDash([8, 8]);
+  ctx.strokeStyle = COLOR_CENTER_LINE;
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(CANVAS_W / 2, 0);
+  ctx.lineTo(CANVAS_W / 2, CANVAS_H);
+  ctx.stroke();
+  ctx.setLineDash([]);
+
+  // Score display (large, in center)
+  ctx.font = '48px monospace';
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'top';
+  ctx.fillStyle = 'rgba(255,238,0,0.12)';
+  ctx.fillText(playerScore + '   ' + cpuScore, CANVAS_W / 2, 20);
+
+  // Particle trail
+  for (const p of particles) {
+    const alpha = p.life * 0.6;
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, BALL_RADIUS * 0.5 * p.life, 0, Math.PI * 2);
+    ctx.fillStyle = `rgba(255,238,0,${alpha})`;
+    ctx.fill();
+  }
+
+  // Ball with glow
+  ctx.shadowColor = COLOR_BALL;
+  ctx.shadowBlur = 15;
+  ctx.beginPath();
+  ctx.arc(ballX, ballY, BALL_RADIUS, 0, Math.PI * 2);
+  ctx.fillStyle = COLOR_BALL;
+  ctx.fill();
+  ctx.shadowBlur = 0;
+
+  // Player paddle with glow
+  ctx.shadowColor = COLOR_PLAYER;
+  ctx.shadowBlur = 12;
+  ctx.fillStyle = COLOR_PLAYER;
+  ctx.fillRect(PADDLE_MARGIN, playerY, PADDLE_W, PADDLE_H);
+  ctx.shadowBlur = 0;
+
+  // CPU paddle with glow
+  ctx.shadowColor = COLOR_CPU;
+  ctx.shadowBlur = 12;
+  ctx.fillStyle = COLOR_CPU;
+  ctx.fillRect(CANVAS_W - PADDLE_MARGIN - PADDLE_W, cpuY, PADDLE_W, PADDLE_H);
+  ctx.shadowBlur = 0;
+}
+
+// ── Event listeners ─────────────────────────────────────────────────────────
+startBtn.addEventListener('click', startGame);
+restartBtn.addEventListener('click', () => {
+  gameOverOverlay.style.display = 'none';
+  overlay.style.display = 'flex';
+});

--- a/public/games/pong/index.html
+++ b/public/games/pong/index.html
@@ -1,0 +1,352 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Photon Paddle — Retro Arcade</title>
+  <link rel="stylesheet" href="/css/main.css" />
+  <style>
+    .game-layout {
+      display: flex;
+      gap: 24px;
+      justify-content: center;
+      align-items: flex-start;
+      padding: 20px;
+      flex-wrap: wrap;
+    }
+    .game-main {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      user-select: none;
+      max-width: 100%;
+      overflow: hidden;
+    }
+    .game-main h1 {
+      font-size: 1.4rem;
+      letter-spacing: 0.2em;
+      text-shadow: 0 0 10px #ffee00, 0 0 20px #ffee00;
+      margin-bottom: 0.4rem;
+      color: #ffee00;
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+    }
+    #hud {
+      display: flex;
+      gap: 1.5rem;
+      font-size: 0.9rem;
+      margin-bottom: 0.4rem;
+      text-shadow: 0 0 6px #0ff;
+      color: #0ff;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    #canvas-wrapper { position: relative; max-width: 100%; }
+    canvas {
+      display: block;
+      border: 2px solid #ffee00;
+      box-shadow: 0 0 20px #ffee00, 0 0 40px #aa9900;
+      max-width: 100%;
+      height: auto;
+    }
+    #overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.82);
+      color: #ffee00;
+      gap: 0.8rem;
+    }
+    #overlay h2 {
+      font-size: 1.8rem;
+      text-shadow: 0 0 10px #ffee00;
+      letter-spacing: 0.2em;
+      font-family: var(--font-pixel);
+      word-break: break-word;
+      overflow-wrap: break-word;
+      text-align: center;
+      max-width: 90%;
+    }
+    #overlay p {
+      font-size: 0.95rem;
+      opacity: 0.85;
+      text-align: center;
+      max-width: 380px;
+      line-height: 1.6;
+    }
+    #overlay button {
+      background: transparent;
+      border: 2px solid #ffee00;
+      color: #ffee00;
+      font-family: inherit;
+      font-size: 1.1rem;
+      padding: 0.5rem 2rem;
+      cursor: pointer;
+      text-shadow: 0 0 6px #ffee00;
+      box-shadow: 0 0 10px #ffee00;
+      letter-spacing: 0.1em;
+    }
+    #overlay button:hover { background: rgba(255,238,0,0.1); }
+    #overlay .difficulty-selector {
+      display: flex;
+      gap: 0.6rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    #overlay .diff-btn {
+      background: transparent;
+      border: 2px solid #555;
+      color: #888;
+      font-family: inherit;
+      font-size: 0.85rem;
+      padding: 0.35rem 1rem;
+      cursor: pointer;
+      letter-spacing: 0.05em;
+      transition: all 0.15s;
+    }
+    #overlay .diff-btn.active {
+      border-color: #ffee00;
+      color: #ffee00;
+      text-shadow: 0 0 6px #ffee00;
+      box-shadow: 0 0 8px rgba(255,238,0,0.3);
+    }
+    #overlay .diff-btn:hover { border-color: #ffee00; color: #ffee00; }
+    #game-over-overlay {
+      position: absolute;
+      inset: 0;
+      display: none;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      background: rgba(0,0,0,0.85);
+      color: #ffee00;
+      gap: 0.8rem;
+    }
+    #game-over-overlay h2 {
+      font-size: 1.8rem;
+      text-shadow: 0 0 10px #ffee00;
+      letter-spacing: 0.2em;
+      font-family: var(--font-pixel);
+      text-align: center;
+    }
+    #game-over-overlay p {
+      font-size: 0.95rem;
+      opacity: 0.85;
+      text-align: center;
+      line-height: 1.6;
+    }
+    #game-over-overlay button {
+      background: transparent;
+      border: 2px solid #ffee00;
+      color: #ffee00;
+      font-family: inherit;
+      font-size: 1.1rem;
+      padding: 0.5rem 2rem;
+      cursor: pointer;
+      text-shadow: 0 0 6px #ffee00;
+      box-shadow: 0 0 10px #ffee00;
+      letter-spacing: 0.1em;
+    }
+    #game-over-overlay button:hover { background: rgba(255,238,0,0.1); }
+
+    /* Leaderboard panel */
+    .game-leaderboard {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 16px;
+      min-width: 220px;
+      max-width: 280px;
+    }
+    .game-leaderboard h3 {
+      font-family: var(--font-pixel);
+      font-size: 0.55rem;
+      color: var(--neon-gold);
+      text-shadow: 0 0 6px rgba(255,215,0,0.4);
+      margin-bottom: 12px;
+      text-align: center;
+    }
+    .lb-list { list-style: none; font-size: 0.8rem; }
+    .lb-list li {
+      display: flex;
+      justify-content: space-between;
+      padding: 4px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .lb-list li:last-child { border-bottom: none; }
+    .lb-rank { color: var(--neon-cyan); min-width: 28px; }
+    .lb-name { flex: 1; margin: 0 8px; }
+    .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
+
+    @media (max-width: 900px) {
+      .game-layout { flex-direction: column; align-items: center; }
+      .game-leaderboard { max-width: 100%; min-width: 280px; }
+    }
+    @media (max-width: 480px) {
+      #hud {
+        font-size: 0.7rem;
+        gap: 0.4rem 0.8rem;
+      }
+      #overlay, #game-over-overlay {
+        overflow-y: auto;
+        gap: 0.4rem;
+        padding: 0.5rem;
+      }
+      #overlay h2, #game-over-overlay h2 {
+        font-size: 1.1rem;
+        letter-spacing: 0.1em;
+      }
+      #overlay p, #game-over-overlay p {
+        font-size: 0.7rem;
+        max-width: 95%;
+        line-height: 1.3;
+      }
+      #overlay button, #game-over-overlay button {
+        font-size: 0.85rem;
+        padding: 0.35rem 1.2rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <!-- Navbar -->
+  <nav class="navbar">
+    <a href="/" class="navbar-brand">RETRO ARCADE</a>
+    <div class="navbar-links">
+      <a href="/leaderboard.html">Leaderboard</a>
+      <span id="nav-auth-links" style="display:flex;gap:20px;">
+        <a href="/auth/login.html">Login</a>
+        <a href="/auth/register.html">Register</a>
+      </span>
+      <span id="nav-user-info" style="display:none;align-items:center;gap:12px;">
+        <span class="navbar-user" id="nav-username"></span>
+        <a href="#" id="nav-logout-btn">Logout</a>
+      </span>
+    </div>
+  </nav>
+
+  <div class="game-layout">
+    <div class="game-main">
+      <h1>PHOTON PADDLE</h1>
+      <div id="hud">
+        <span>PLAYER: <span id="player-score">0</span></span>
+        <span>CPU: <span id="cpu-score">0</span></span>
+        <span>RALLIES: <span id="rallies">0</span></span>
+      </div>
+      <div id="canvas-wrapper">
+        <canvas id="canvas" width="700" height="520"></canvas>
+        <div id="overlay">
+          <h2>PHOTON PADDLE</h2>
+          <p>
+            Up/Down or W/S — Move paddle<br>
+            First to 10 wins. Rally count = your score.
+          </p>
+          <div class="difficulty-selector">
+            <button class="diff-btn" data-diff="easy">EASY</button>
+            <button class="diff-btn active" data-diff="normal">NORMAL</button>
+            <button class="diff-btn" data-diff="hard">HARD</button>
+          </div>
+          <button id="start-btn">START GAME</button>
+        </div>
+        <div id="game-over-overlay">
+          <h2 id="game-over-title">YOU WIN!</h2>
+          <p id="game-over-info">Total rallies: 0</p>
+          <button id="restart-btn">PLAY AGAIN</button>
+        </div>
+      </div>
+      <div class="touch-controls" id="touch-controls">
+        <div class="touch-controls-row">
+          <button class="dpad-btn" data-key="ArrowUp" style="width:64px;height:64px;font-size:1.6rem;">&#9650;</button>
+          <button class="dpad-btn" data-key="ArrowDown" style="width:64px;height:64px;font-size:1.6rem;">&#9660;</button>
+        </div>
+        <div class="touch-hint">TAP TO MOVE PADDLE</div>
+      </div>
+    </div>
+
+    <div class="game-leaderboard">
+      <h3>TOP SCORES</h3>
+      <ul class="lb-list" id="lb-list">
+        <li class="lb-empty">Loading...</li>
+      </ul>
+    </div>
+  </div>
+
+  <script src="/js/api.js"></script>
+  <script>
+    // Touch controls — paddle movement buttons
+    document.querySelectorAll('.dpad-btn[data-key]').forEach(btn => {
+      let interval = null;
+      const startMove = (e) => {
+        e.preventDefault();
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        interval = setInterval(() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: btn.dataset.key, bubbles: true }));
+        }, 80);
+      };
+      const stopMove = (e) => {
+        e.preventDefault();
+        clearInterval(interval);
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: btn.dataset.key, bubbles: true }));
+      };
+      btn.addEventListener('touchstart', startMove, { passive: false });
+      btn.addEventListener('touchend', stopMove, { passive: false });
+      btn.addEventListener('touchcancel', stopMove, { passive: false });
+    });
+
+    async function loadMiniLeaderboard() {
+      const list = document.getElementById('lb-list');
+      if (!list) return;
+      try {
+        const res = await api.get('/api/scores/pong');
+        if (!res || !res.ok) throw new Error('fetch failed');
+        const scores = await res.json();
+        const user = await api.getUser();
+
+        if (scores.length === 0) {
+          list.innerHTML = '<li class="lb-empty">No scores yet</li>';
+          return;
+        }
+
+        list.innerHTML = '';
+        for (const s of scores) {
+          const isSelf = user && s.username === user.username;
+          const li = document.createElement('li');
+          if (isSelf) li.style.color = 'var(--neon-gold)';
+          const rankSpan = document.createElement('span');
+          rankSpan.className = 'lb-rank';
+          rankSpan.textContent = '#' + s.rank;
+          const nameSpan = document.createElement('span');
+          nameSpan.className = 'lb-name';
+          nameSpan.textContent = isSelf ? s.username + ' (YOU)' : s.username;
+          const scoreSpan = document.createElement('span');
+          scoreSpan.className = 'lb-score';
+          scoreSpan.textContent = s.score.toLocaleString();
+          li.append(rankSpan, nameSpan, scoreSpan);
+          list.appendChild(li);
+        }
+      } catch (err) {
+        console.error('Mini-leaderboard load failed:', err);
+        list.innerHTML = '<li class="lb-empty">Failed to load</li>';
+      }
+    }
+    window.loadMiniLeaderboard = loadMiniLeaderboard;
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const logoutBtn = document.getElementById('nav-logout-btn');
+      if (logoutBtn) {
+        logoutBtn.addEventListener('click', (e) => {
+          e.preventDefault();
+          api.logout();
+        });
+      }
+      loadMiniLeaderboard();
+    });
+  </script>
+  <script src="game.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -72,6 +72,14 @@
         <div class="card-top-score" id="top-frogger">TOP: ---</div>
         <a href="/games/frogger/" class="btn" style="border-color:#cc44ff;color:#cc44ff;box-shadow:0 0 8px rgba(204,68,255,0.2);">PLAY</a>
       </div>
+
+      <!-- Photon Paddle -->
+      <div class="card">
+        <h3>PHOTON PADDLE</h3>
+        <p>Pong vs CPU with increasing ball speed, difficulty modes, and rally tracking. First to 10 wins.</p>
+        <div class="card-top-score" id="top-pong">TOP: ---</div>
+        <a href="/games/pong/" class="btn" style="border-color:#ffee00;color:#ffee00;box-shadow:0 0 8px rgba(255,238,0,0.2);">PLAY</a>
+      </div>
     </div>
 
     <div style="text-align:center;margin:30px 0;">
@@ -93,6 +101,7 @@
         { id: 'neon-growth', el: 'top-snake' },
         { id: 'space-invaders', el: 'top-space-invaders' },
         { id: 'frogger', el: 'top-frogger' },
+        { id: 'pong', el: 'top-pong' },
       ];
 
       for (const game of games) {

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -47,6 +47,7 @@
               <th>Neon Growth</th>
               <th>Asteroid Def.</th>
               <th>Neon Hopper</th>
+              <th>Photon Paddle</th>
             </tr>
           </thead>
           <tbody id="overall-tbody"></tbody>
@@ -62,6 +63,7 @@
         <option value="neon-growth">Neon Growth</option>
         <option value="space-invaders">Asteroid Defense Surge</option>
         <option value="frogger">Neon Hopper</option>
+        <option value="pong">Photon Paddle</option>
       </select>
       <div class="loading" id="game-loading">LOADING...</div>
       <div class="table-wrap" id="game-table-wrap" style="display:none;">
@@ -101,6 +103,7 @@
       'neon-growth': 'Neon Growth',
       'space-invaders': 'Asteroid Def.',
       'frogger': 'Neon Hopper',
+      'pong': 'Photon Paddle',
     };
 
     // ---- Tab switching ----
@@ -154,6 +157,7 @@
           const snakePts = entry.breakdown?.['neon-growth']?.points ?? 0;
           const spacePts = entry.breakdown?.['space-invaders']?.points ?? 0;
           const froggerPts = entry.breakdown?.['frogger']?.points ?? 0;
+          const pongPts = entry.breakdown?.pong?.points ?? 0;
 
           const rankTd = document.createElement('td');
           rankTd.className = rankClass(entry.rank);
@@ -170,7 +174,9 @@
           spaceTd.textContent = spacePts;
           const froggerTd = document.createElement('td');
           froggerTd.textContent = froggerPts;
-          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd);
+          const pongTd = document.createElement('td');
+          pongTd.textContent = pongPts;
+          tr.append(rankTd, nameTd, totalTd, pacTd, snakeTd, spaceTd, froggerTd, pongTd);
           tbody.appendChild(tr);
         }
 

--- a/src/routes/leaderboard.js
+++ b/src/routes/leaderboard.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { pointsForPosition } from '../utils/f1-points.js';
 
-const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger'];
+const GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong'];
 
 /**
  * Computes per-game rankings (best score per user) for a given game.

--- a/src/routes/scores.js
+++ b/src/routes/scores.js
@@ -1,7 +1,7 @@
 import { db } from '../db.js';
 import { authenticate } from '../middleware/auth.js';
 
-const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger'];
+const VALID_GAMES = ['pacmaze', 'neon-growth', 'space-invaders', 'frogger', 'pong'];
 const MAX_SCORE = 999999;
 const RATE_LIMIT_WINDOW_MS = 3 * 1000; // 3 seconds — prevents double-submit without blocking back-to-back games
 


### PR DESCRIPTION
## Summary
- Adds complete playable Pong game (PHOTON PADDLE) at /games/pong/
- Player vs CPU with 3 difficulty levels (Easy/Normal/Hard)
- Ball physics with angle-based paddle reflection
- Score to 10, rally tracking for leaderboard
- Particle trail on ball, neon glow effects
- Score submission and mini-leaderboard
- Mobile touch controls
- Added to homepage, leaderboard, VALID_GAMES, GAMES arrays

Closes #69

## Test plan
- [ ] `curl -s http://localhost:3000/games/pong/ | grep -q "PHOTON PADDLE"`
- [ ] Ball bounces, paddles move, CPU tracks ball
- [ ] Score to 10, match ends
- [ ] Score submits on match end

🤖 Generated with [Claude Code](https://claude.com/claude-code)