### PR TITLE
fix: circle-based collision detection for Pac-Man

### DIFF
--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -17,6 +17,7 @@
   const SCORE_PER_DOT = 10;
   const SCORE_PER_POWER = 50;
   const GHOST_EAT_BASE = 200;
+  const COLLISION_DIST = CELL * 0.6; // circle collision — ~60% of cell, forgiving like original Pac-Man
 
   // -- Maze layouts (3 layouts, 21x21) ------------------------------------------
   // 0=empty(no dot), 1=wall, 2=dot, 3=power-pellet, 4=ghost-house
@@ -452,12 +453,14 @@
     }
   }
 
-  // -- Collision ------------------------------------------------------------------
+  // -- Collision (circle-based on interpolated pixel positions) ------------------
   function checkCollisions(now) {
     for (const ghost of ghosts) {
       if (ghost.dead) continue;
       if (!ghost.released) continue;
-      if (ghost.col === player.col && ghost.row === player.row) {
+      const dx = ghost.x - player.x;
+      const dy = ghost.y - player.y;
+      if (Math.sqrt(dx * dx + dy * dy) < COLLISION_DIST) {
         if (now < scaredUntil) {
           // Eat ghost (200/400/800/1600 cascade)
           const pts = GHOST_EAT_BASE * Math.pow(2, ghostEatChain) * scoreMultiplier;
@@ -851,7 +854,11 @@
       lastItemSpawn = now;
     }
 
-    // Collisions
+    // Smooth interpolation (must happen before collision check for accurate pixel positions)
+    interpolate(player, PLAYER_SPEED_MS, now);
+    ghosts.forEach(g => { if (g.released && !g.dead) interpolate(g, GHOST_SPEED_MS, now); });
+
+    // Collisions (circle-based on interpolated pixel positions)
     checkCollisions(now);
     if (state !== 'playing') {
       updateHUD();
@@ -873,10 +880,6 @@
         }
       );
     }
-
-    // Smooth interpolation for rendering
-    interpolate(player, PLAYER_SPEED_MS, now);
-    ghosts.forEach(g => { if (g.released && !g.dead) interpolate(g, GHOST_SPEED_MS, now); });
 
     updateHUD();
     draw(now);


### PR DESCRIPTION
## Summary
- Replaces grid-based (bounding box) collision with circle/radius-based detection using Euclidean distance on interpolated pixel positions
- Collision threshold set to 60% of cell size (~12px vs visual touching at 16px), requiring visible sprite overlap — forgiving like original Pac-Man
- Moved interpolation before collision check so distance is calculated on actual visual positions, not raw grid targets

## Technical details
- `COLLISION_DIST = CELL * 0.6` = 12px (visual sprite radius = 8px each, touching at 16px)
- `Math.sqrt(dx² + dy²) < COLLISION_DIST` replaces `ghost.col === player.col && ghost.row === player.row`
- Both ghost-eating (power pellet) and player-hit use the same circle check

## Test plan
- [x] All 188 existing tests pass
- [ ] Play Pac-Maze: verify ghosts no longer kill from across the cell
- [ ] Verify you can pass close to ghosts without dying (forgiving feel)
- [ ] Verify eating ghosts during power pellet still works at close range
- [ ] Verify ghost cascade scoring (200/400/800/1600) still works

Fixes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced collision detection system between the player and ghosts for more responsive and natural gameplay encounters.
* Improved detection timing consistency by aligning collision checks with visual rendering to ensure fair and predictable ghost interactions throughout gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->