### PR TITLE
feat: add Easy/Normal/Hard difficulty to all games (#83)

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -531,6 +531,7 @@ canvas {
 .dpad-btn:active {
   background: rgba(0, 255, 255, 0.3);
   box-shadow: 0 0 12px var(--neon-cyan);
+  transform: scale(0.95);
 }
 
 .dpad-btn--blank {
@@ -569,6 +570,7 @@ canvas {
 .touch-btn-fire:active {
   background: rgba(255, 0, 255, 0.3);
   box-shadow: 0 0 12px var(--neon-pink);
+  transform: scale(0.95);
 }
 
 .touch-hint {

--- a/public/games/asteroids/game.js
+++ b/public/games/asteroids/game.js
@@ -58,6 +58,35 @@ const scoreEl = document.getElementById('score');
 const livesEl = document.getElementById('lives');
 const waveEl = document.getElementById('wave');
 
+// Swipe detection for ship control
+(function() {
+  let touchStartX = 0, touchStartY = 0, touchStartTime = 0;
+  canvas.addEventListener('touchstart', function(e) {
+    touchStartX = e.touches[0].clientX;
+    touchStartY = e.touches[0].clientY;
+    touchStartTime = Date.now();
+  }, { passive: true });
+  canvas.addEventListener('touchend', function(e) {
+    const dx = e.changedTouches[0].clientX - touchStartX;
+    const dy = e.changedTouches[0].clientY - touchStartY;
+    if (Date.now() - touchStartTime > 400) return;
+    var absDx = Math.abs(dx), absDy = Math.abs(dy);
+    if (absDx < 30 && absDy < 30) return;
+    var key;
+    if (absDx > absDy) {
+      key = dx > 0 ? 'ArrowRight' : 'ArrowLeft';
+    } else if (dy < 0) {
+      key = 'ArrowUp';
+    } else {
+      return;
+    }
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: key, bubbles: true }));
+    setTimeout(function() {
+      document.dispatchEvent(new KeyboardEvent('keyup', { key: key, bubbles: true }));
+    }, 50);
+  }, { passive: true });
+})();
+
 let running = false;
 let gameOver = false;
 let score = 0;
@@ -563,6 +592,7 @@ function checkCollisions() {
 }
 
 function killShip() {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
   spawnParticles(ship.x, ship.y, 20);
   lives--;
   updateLivesDisplay();

--- a/public/games/asteroids/game.js
+++ b/public/games/asteroids/game.js
@@ -788,11 +788,11 @@ startBtn.addEventListener('click', () => {
 function initDifficultySelector() {
   const btns = document.querySelectorAll('#difficulty-selector .diff-btn');
   btns.forEach(btn => {
-    if (btn.dataset.diff === currentDifficulty) btn.classList.add('active');
+    if (btn.dataset.difficulty === currentDifficulty) btn.classList.add('diff-active');
     btn.addEventListener('click', () => {
-      btns.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      setDifficulty(btn.dataset.diff);
+      btns.forEach(b => b.classList.remove('diff-active'));
+      btn.classList.add('diff-active');
+      setDifficulty(btn.dataset.difficulty);
     });
   });
 }

--- a/public/games/asteroids/game.js
+++ b/public/games/asteroids/game.js
@@ -25,6 +25,16 @@ const INVULN_TIME = 2000; // ms
 const MAX_LIVES = 3;
 const PARTICLE_LIFE = 30; // frames
 
+// ── Difficulty ─────────────────────────────────────────────────────────────
+const DIFFICULTY_CONFIG = {
+  easy:   { label: 'EASY',   maxLives: 5, asteroidSpeedMult: 0.7, invulnTime: 3000, startingAsteroids: 3 },
+  normal: { label: 'NORMAL', maxLives: 3, asteroidSpeedMult: 1.0, invulnTime: 2000, startingAsteroids: 3 },
+  hard:   { label: 'HARD',   maxLives: 2, asteroidSpeedMult: 1.3, invulnTime: 1500, startingAsteroids: 5 },
+};
+let currentDifficulty = localStorage.getItem('asteroids-difficulty') || 'normal';
+let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('asteroids-difficulty', d); }
+
 const ASTEROID_SIZES = {
   large:  { radius: 40, points: 25,  speed: 1.0, children: 'medium' },
   medium: { radius: 20, points: 50,  speed: 1.8, children: 'small' },
@@ -90,7 +100,7 @@ const waveEl = document.getElementById('wave');
 let running = false;
 let gameOver = false;
 let score = 0;
-let lives = MAX_LIVES;
+let lives = activeDiff.maxLives;
 let wave = 0;
 let lastTime = 0;
 let lastFireTime = 0;
@@ -147,7 +157,7 @@ function createShip() {
     angle: -Math.PI / 2, // pointing up
     thrusting: false,
     invulnerable: true,
-    invulnTimer: INVULN_TIME,
+    invulnTimer: activeDiff.invulnTime,
     visible: true,
     flickerTimer: 0,
   };
@@ -285,10 +295,11 @@ function drawBullets() {
 // ── Asteroids ───────────────────────────────────────────────────────────────
 function createAsteroid(size, x, y, vx, vy) {
   const def = ASTEROID_SIZES[size];
+  const sm = activeDiff.asteroidSpeedMult;
   return {
     x, y,
-    vx: vx ?? rand(-def.speed, def.speed),
-    vy: vy ?? rand(-def.speed, def.speed),
+    vx: (vx ?? rand(-def.speed, def.speed)) * sm,
+    vy: (vy ?? rand(-def.speed, def.speed)) * sm,
     size,
     radius: def.radius,
     shape: generateAsteroidShape(def.radius),
@@ -299,7 +310,7 @@ function createAsteroid(size, x, y, vx, vy) {
 
 function spawnWaveAsteroids() {
   wave++;
-  const count = wave + 3;
+  const count = wave + activeDiff.startingAsteroids;
   for (let i = 0; i < count; i++) {
     // Spawn from edges
     let x, y;
@@ -615,7 +626,7 @@ function updateLivesDisplay() {
 // ── Game flow ───────────────────────────────────────────────────────────────
 function startGame() {
   score = 0;
-  lives = MAX_LIVES;
+  lives = activeDiff.maxLives;
   wave = 0;
   bullets = [];
   asteroids = [];
@@ -635,6 +646,8 @@ function startGame() {
   spawnWaveAsteroids();
 
   overlay.style.display = 'none';
+  const ds = document.getElementById('difficulty-selector');
+  if (ds) ds.style.display = 'none';
   running = true;
   lastTime = performance.now();
   requestAnimationFrame(gameLoop);
@@ -649,6 +662,8 @@ function endGame() {
   overlay.querySelector('p').textContent = 'Final Score: ' + score.toLocaleString();
   startBtn.textContent = 'PLAY AGAIN';
   overlay.style.display = 'flex';
+  const ds = document.getElementById('difficulty-selector');
+  if (ds) ds.style.display = 'flex';
 
   // Submit score
   submitScore();
@@ -656,7 +671,7 @@ function endGame() {
 
 async function submitScore() {
   try {
-    const res = await api.post('/api/scores/asteroids', { score });
+    const res = await api.post('/api/scores/asteroids', { score, difficulty: currentDifficulty });
     if (res && res.ok) {
       const data = await res.json();
       const rankInfo = document.createElement('p');
@@ -768,3 +783,17 @@ startBtn.addEventListener('click', () => {
   startBtn.textContent = 'START GAME';
   startGame();
 });
+
+// ── Difficulty selector ────────────────────────────────────────────────────
+function initDifficultySelector() {
+  const btns = document.querySelectorAll('#difficulty-selector .diff-btn');
+  btns.forEach(btn => {
+    if (btn.dataset.diff === currentDifficulty) btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      btns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      setDifficulty(btn.dataset.diff);
+    });
+  });
+}
+initDifficultySelector();

--- a/public/games/asteroids/index.html
+++ b/public/games/asteroids/index.html
@@ -95,6 +95,36 @@
     }
     #overlay button:hover { background: rgba(51,255,136,0.1); }
 
+    /* Difficulty selector */
+    #difficulty-selector {
+      display: flex;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+    .diff-btn {
+      background: transparent;
+      border: 1px solid #33ff88;
+      color: #33ff88;
+      font-family: inherit;
+      font-size: 0.75rem;
+      padding: 0.25rem 0.7rem;
+      cursor: pointer;
+      letter-spacing: 0.08em;
+      opacity: 0.6;
+      transition: opacity 0.15s, box-shadow 0.15s;
+    }
+    .diff-btn:hover { opacity: 0.85; }
+    .diff-btn.active {
+      opacity: 1;
+      box-shadow: 0 0 8px #33ff88;
+      border-width: 2px;
+    }
+    .lb-diff {
+      font-size: 0.6rem;
+      opacity: 0.5;
+      margin-left: 4px;
+    }
+
     /* Leaderboard panel */
     .game-leaderboard {
       background: var(--surface);
@@ -190,6 +220,11 @@
             Space — Fire<br>
             Destroy asteroids. Survive the void.
           </p>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-diff="easy">EASY</button>
+            <button class="diff-btn" data-diff="normal">NORMAL</button>
+            <button class="diff-btn" data-diff="hard">HARD</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -279,6 +314,12 @@
           const scoreSpan = document.createElement('span');
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
+          if (s.difficulty) {
+            const diffSpan = document.createElement('span');
+            diffSpan.className = 'lb-diff';
+            diffSpan.textContent = s.difficulty.charAt(0).toUpperCase();
+            scoreSpan.appendChild(diffSpan);
+          }
           li.append(rankSpan, nameSpan, scoreSpan);
           list.appendChild(li);
         }

--- a/public/games/asteroids/index.html
+++ b/public/games/asteroids/index.html
@@ -114,7 +114,7 @@
       transition: opacity 0.15s, box-shadow 0.15s;
     }
     .diff-btn:hover { opacity: 0.85; }
-    .diff-btn.active {
+    .diff-btn.diff-active {
       opacity: 1;
       box-shadow: 0 0 8px #33ff88;
       border-width: 2px;
@@ -221,9 +221,9 @@
             Destroy asteroids. Survive the void.
           </p>
           <div id="difficulty-selector">
-            <button class="diff-btn" data-diff="easy">EASY</button>
-            <button class="diff-btn" data-diff="normal">NORMAL</button>
-            <button class="diff-btn" data-diff="hard">HARD</button>
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
           </div>
           <button id="start-btn">START GAME</button>
         </div>
@@ -314,10 +314,10 @@
           const scoreSpan = document.createElement('span');
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
-          if (s.difficulty) {
+          if (s.difficulty && s.difficulty !== 'normal') {
             const diffSpan = document.createElement('span');
             diffSpan.className = 'lb-diff';
-            diffSpan.textContent = s.difficulty.charAt(0).toUpperCase();
+            diffSpan.textContent = s.difficulty === 'easy' ? 'E' : 'H';
             scoreSpan.appendChild(diffSpan);
           }
           li.append(rankSpan, nameSpan, scoreSpan);

--- a/public/games/asteroids/index.html
+++ b/public/games/asteroids/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>Void Drifter — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>
@@ -19,6 +19,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow: hidden;
     }
@@ -49,6 +50,8 @@
       box-shadow: 0 0 20px #33ff88, 0 0 40px #009944;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;
@@ -192,10 +195,10 @@
       </div>
       <div class="touch-controls" id="touch-controls">
         <div class="touch-controls-row">
-          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
-          <button class="dpad-btn" data-key="ArrowUp" style="width:64px;height:64px;font-size:1.6rem;">&#9650;</button>
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:72px;height:72px;font-size:1.8rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowUp" style="width:72px;height:72px;font-size:1.8rem;">&#9650;</button>
           <button class="touch-btn-fire" id="fire-btn">FIRE</button>
-          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:72px;height:72px;font-size:1.8rem;">&#9654;</button>
         </div>
         <div class="touch-hint">ROTATE &bull; THRUST &bull; FIRE</div>
       </div>

--- a/public/games/breakout/game.js
+++ b/public/games/breakout/game.js
@@ -10,6 +10,16 @@
 const CANVAS_W = 700;
 const CANVAS_H = 520;
 
+// ── Difficulty ────────────────────────────────────────────────────────────
+const DIFFICULTY_CONFIG = {
+  easy:   { label: 'EASY',   ballSpeed: 3.5, ballSpeedInc: 0.2, paddleWidth: 120, maxLives: 5 },
+  normal: { label: 'NORMAL', ballSpeed: 4.5, ballSpeedInc: 0.35, paddleWidth: 100, maxLives: 3 },
+  hard:   { label: 'HARD',   ballSpeed: 5.5, ballSpeedInc: 0.5,  paddleWidth: 80,  maxLives: 2 },
+};
+let currentDifficulty = localStorage.getItem('breakout-difficulty') || 'normal';
+let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('breakout-difficulty', d); }
+
 // ── Colors ─────────────────────────────────────────────────────────────────
 const PINK = '#ff3366';
 const ROW_COLORS = ['#ff3366', '#ff6600', '#ffcc00', '#33ff66', '#3399ff', '#cc33ff', '#ff66cc'];
@@ -18,11 +28,8 @@ const TOUGH_DIM = 0.45; // opacity multiplier after first hit
 // ── Layout constants ───────────────────────────────────────────────────────
 const PADDLE_Y_OFFSET = 40; // distance from bottom
 const PADDLE_HEIGHT = 14;
-const PADDLE_BASE_WIDTH = 100;
 const PADDLE_SPEED = 7;
 const BALL_RADIUS = 6;
-const BALL_BASE_SPEED = 4.5;
-const BALL_SPEED_INCREMENT = 0.35; // per level
 
 const BRICK_ROWS = 6;
 const BRICK_COLS = 10;
@@ -32,7 +39,6 @@ const BRICK_PADDING = 4;
 const BRICK_OFFSET_TOP = 50;
 const BRICK_OFFSET_LEFT = (CANVAS_W - (BRICK_COLS * (BRICK_WIDTH + BRICK_PADDING) - BRICK_PADDING)) / 2;
 
-const MAX_LIVES = 3;
 const POWERUP_DROP_CHANCE = 0.20;
 const POWERUP_FALL_SPEED = 2;
 const POWERUP_SIZE = 18;
@@ -59,7 +65,7 @@ const levelEl = document.getElementById('level');
 
 let gameState = 'idle'; // idle | playing | paused | gameover
 let score = 0;
-let lives = MAX_LIVES;
+let lives = activeDiff.maxLives;
 let level = 1;
 let paddle, balls, bricks, powerUps;
 let widePaddleTimer = 0;
@@ -71,16 +77,16 @@ let touchPaddleStartX = null;
 // ── Paddle ─────────────────────────────────────────────────────────────────
 function createPaddle() {
   return {
-    x: CANVAS_W / 2 - PADDLE_BASE_WIDTH / 2,
+    x: CANVAS_W / 2 - activeDiff.paddleWidth / 2,
     y: CANVAS_H - PADDLE_Y_OFFSET,
-    width: PADDLE_BASE_WIDTH,
+    width: activeDiff.paddleWidth,
     height: PADDLE_HEIGHT,
   };
 }
 
 // ── Ball ───────────────────────────────────────────────────────────────────
 function createBall(x, y, dx, dy) {
-  const speed = BALL_BASE_SPEED + BALL_SPEED_INCREMENT * (level - 1);
+  const speed = activeDiff.ballSpeed + activeDiff.ballSpeedInc * (level - 1);
   return {
     x: x,
     y: y,
@@ -142,7 +148,7 @@ function spawnPowerUp(x, y) {
 // ── Init / Reset ───────────────────────────────────────────────────────────
 function initGame() {
   score = 0;
-  lives = MAX_LIVES;
+  lives = activeDiff.maxLives;
   level = 1;
   widePaddleTimer = 0;
   paddle = createPaddle();
@@ -155,7 +161,7 @@ function initGame() {
 function nextLevel() {
   level++;
   widePaddleTimer = 0;
-  paddle.width = PADDLE_BASE_WIDTH;
+  paddle.width = activeDiff.paddleWidth;
   paddle.x = CANVAS_W / 2 - paddle.width / 2;
   balls = [createBall(paddle.x + paddle.width / 2, paddle.y - BALL_RADIUS)];
   bricks = generateBricks();
@@ -167,7 +173,7 @@ function updateHUD() {
   scoreEl.textContent = score;
   levelEl.textContent = level;
   let starStr = '';
-  for (let i = 0; i < MAX_LIVES; i++) {
+  for (let i = 0; i < activeDiff.maxLives; i++) {
     starStr += i < lives ? '\u2733' : '\u2606';
   }
   livesEl.textContent = starStr;
@@ -253,7 +259,7 @@ function update(dt) {
     widePaddleTimer -= dt;
     if (widePaddleTimer <= 0) {
       widePaddleTimer = 0;
-      paddle.width = PADDLE_BASE_WIDTH;
+      paddle.width = activeDiff.paddleWidth;
       // Clamp paddle position
       if (paddle.x + paddle.width > CANVAS_W) paddle.x = CANVAS_W - paddle.width;
     }
@@ -396,7 +402,7 @@ function update(dt) {
 
 function applyPowerUp(kind) {
   if (kind === PU_WIDE) {
-    paddle.width = PADDLE_BASE_WIDTH * WIDE_PADDLE_MULT;
+    paddle.width = activeDiff.paddleWidth * WIDE_PADDLE_MULT;
     if (paddle.x + paddle.width > CANVAS_W) paddle.x = CANVAS_W - paddle.width;
     widePaddleTimer = WIDE_PADDLE_DURATION;
   } else if (kind === PU_MULTI) {
@@ -428,10 +434,12 @@ async function gameOver() {
   overlay.querySelector('p').innerHTML =
     'Final Score: <strong>' + score + '</strong><br>Level Reached: ' + level;
   startBtn.textContent = 'PLAY AGAIN';
+  const diffSel = document.getElementById('difficulty-selector');
+  if (diffSel) diffSel.style.display = '';
 
   // Submit score
   try {
-    await api.post('/api/scores/breakout', { score });
+    await api.post('/api/scores/breakout', { score, difficulty: currentDifficulty });
   } catch (err) {
     console.error('Score submission failed:', err);
   }
@@ -597,10 +605,26 @@ startBtn.addEventListener('click', () => {
     initGame();
   }
   overlay.style.display = 'none';
+  const diffSel = document.getElementById('difficulty-selector');
+  if (diffSel) diffSel.style.display = 'none';
   gameState = 'playing';
   lastTime = 0;
   requestAnimationFrame(gameLoop);
 });
+
+// ── Difficulty selector ────────────────────────────────────────────────────
+function initDifficultySelector() {
+  const btns = document.querySelectorAll('#difficulty-selector .diff-btn');
+  btns.forEach(btn => {
+    if (btn.dataset.diff === currentDifficulty) btn.classList.add('active');
+    btn.addEventListener('click', () => {
+      btns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      setDifficulty(btn.dataset.diff);
+    });
+  });
+}
+initDifficultySelector();
 
 // Initial draw
 initGame();

--- a/public/games/breakout/game.js
+++ b/public/games/breakout/game.js
@@ -616,11 +616,11 @@ startBtn.addEventListener('click', () => {
 function initDifficultySelector() {
   const btns = document.querySelectorAll('#difficulty-selector .diff-btn');
   btns.forEach(btn => {
-    if (btn.dataset.diff === currentDifficulty) btn.classList.add('active');
+    if (btn.dataset.difficulty === currentDifficulty) btn.classList.add('diff-active');
     btn.addEventListener('click', () => {
-      btns.forEach(b => b.classList.remove('active'));
-      btn.classList.add('active');
-      setDifficulty(btn.dataset.diff);
+      btns.forEach(b => b.classList.remove('diff-active'));
+      btn.classList.add('diff-active');
+      setDifficulty(btn.dataset.difficulty);
     });
   });
 }

--- a/public/games/breakout/game.js
+++ b/public/games/breakout/game.js
@@ -356,6 +356,7 @@ function update(dt) {
   // If no balls left, lose a life
   if (balls.length === 0) {
     lives--;
+    if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(100);
     updateHUD();
     if (lives <= 0) {
       gameOver();
@@ -420,6 +421,7 @@ function applyPowerUp(kind) {
 
 // ── Game over ──────────────────────────────────────────────────────────────
 async function gameOver() {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
   gameState = 'gameover';
   overlay.style.display = 'flex';
   overlay.querySelector('h2').textContent = 'GAME OVER';

--- a/public/games/breakout/index.html
+++ b/public/games/breakout/index.html
@@ -95,6 +95,27 @@
     }
     #overlay button:hover { background: rgba(255,51,102,0.1); }
 
+    /* Difficulty selector */
+    #difficulty-selector { display: flex; gap: 0.5rem; }
+    .diff-btn {
+      background: transparent;
+      border: 1px solid #ff3366;
+      color: #ff3366;
+      font-family: inherit;
+      font-size: 0.75rem;
+      padding: 0.25rem 0.7rem;
+      cursor: pointer;
+      letter-spacing: 0.05em;
+      opacity: 0.55;
+      transition: opacity 0.15s, box-shadow 0.15s;
+    }
+    .diff-btn:hover { opacity: 0.8; }
+    .diff-btn.active {
+      opacity: 1;
+      box-shadow: 0 0 8px #ff3366;
+      border-width: 2px;
+    }
+
     /* Leaderboard panel */
     .game-leaderboard {
       background: var(--surface);
@@ -123,6 +144,7 @@
     .lb-rank { color: var(--neon-cyan); min-width: 28px; }
     .lb-name { flex: 1; margin: 0 8px; }
     .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-diff { font-size: 0.55rem; opacity: 0.6; margin-left: 4px; vertical-align: middle; }
     .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
 
     @media (max-width: 900px) {
@@ -152,6 +174,7 @@
         font-size: 0.85rem;
         padding: 0.35rem 1.2rem;
       }
+      .diff-btn { font-size: 0.6rem; padding: 0.2rem 0.5rem; }
     }
   </style>
 </head>
@@ -189,6 +212,11 @@
             Space / Tap — Launch ball<br>
             Smash neon bricks, grab power-ups!
           </p>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-diff="easy">EASY</button>
+            <button class="diff-btn" data-diff="normal">NORMAL</button>
+            <button class="diff-btn" data-diff="hard">HARD</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -277,6 +305,12 @@
           const scoreSpan = document.createElement('span');
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const diffTag = document.createElement('span');
+            diffTag.className = 'lb-diff';
+            diffTag.textContent = s.difficulty.toUpperCase();
+            scoreSpan.appendChild(diffTag);
+          }
           li.append(rankSpan, nameSpan, scoreSpan);
           list.appendChild(li);
         }

--- a/public/games/breakout/index.html
+++ b/public/games/breakout/index.html
@@ -110,7 +110,7 @@
       transition: opacity 0.15s, box-shadow 0.15s;
     }
     .diff-btn:hover { opacity: 0.8; }
-    .diff-btn.active {
+    .diff-btn.diff-active {
       opacity: 1;
       box-shadow: 0 0 8px #ff3366;
       border-width: 2px;
@@ -213,9 +213,9 @@
             Smash neon bricks, grab power-ups!
           </p>
           <div id="difficulty-selector">
-            <button class="diff-btn" data-diff="easy">EASY</button>
-            <button class="diff-btn" data-diff="normal">NORMAL</button>
-            <button class="diff-btn" data-diff="hard">HARD</button>
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
           </div>
           <button id="start-btn">START GAME</button>
         </div>

--- a/public/games/breakout/index.html
+++ b/public/games/breakout/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>Brick Blitz — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>
@@ -19,6 +19,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow: hidden;
     }
@@ -49,6 +50,8 @@
       box-shadow: 0 0 20px #ff3366, 0 0 40px #8000ff;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;
@@ -191,9 +194,9 @@
       </div>
       <div class="touch-controls" id="touch-controls">
         <div class="touch-controls-row">
-          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:72px;height:72px;font-size:1.8rem;">&#9664;</button>
           <button class="touch-btn-fire" id="fire-btn">LAUNCH</button>
-          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:72px;height:72px;font-size:1.8rem;">&#9654;</button>
         </div>
         <div class="touch-hint">DRAG TO MOVE &bull; TAP TO LAUNCH</div>
       </div>

--- a/public/games/frogger/game.js
+++ b/public/games/frogger/game.js
@@ -71,7 +71,7 @@ function setDifficulty(diff) {
 // ── Haptic feedback ────────────────────────────────────────────────────────
 
 function hapticPulse(ms) {
-  if (navigator.vibrate) {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) {
     navigator.vibrate(ms);
   }
 }

--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -477,6 +477,7 @@
   }
 
   function playerHit() {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
     lives--;
     if (lives <= 0) {
       state = 'gameover';

--- a/public/games/pacmaze/game.js
+++ b/public/games/pacmaze/game.js
@@ -19,6 +19,16 @@
   const GHOST_EAT_BASE = 200;
   const COLLISION_DIST = CELL * 0.6; // circle collision — ~60% of cell, forgiving like original Pac-Man
 
+  // -- Difficulty settings --------------------------------------------------------
+  const DIFFICULTY_CONFIG = {
+    easy:   { label: 'EASY',   ghostSpeedMs: 280, scaredDuration: 12000, lives: 5, collisionDist: 0.45 },
+    normal: { label: 'NORMAL', ghostSpeedMs: 220, scaredDuration: 8000,  lives: 3, collisionDist: 0.6 },
+    hard:   { label: 'HARD',   ghostSpeedMs: 180, scaredDuration: 5000,  lives: 2, collisionDist: 0.7 },
+  };
+  let currentDifficulty = localStorage.getItem('pacmaze-difficulty') || 'normal';
+  let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+  function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('pacmaze-difficulty', d); }
+
   // -- Maze layouts (3 layouts, 21x21) ------------------------------------------
   // 0=empty(no dot), 1=wall, 2=dot, 3=power-pellet, 4=ghost-house
   const MAZES = [
@@ -237,7 +247,7 @@
 
   function initGame() {
     score = 0;
-    lives = 3;
+    lives = activeDiff.lives;
     initLevel(1, 0);
   }
 
@@ -263,7 +273,7 @@
   function moveGhost(ghost, now) {
     if (!ghost.released) return;
     if (ghost.dead) {
-      ghost.deadTimer -= GHOST_SPEED_MS;
+      ghost.deadTimer -= activeDiff.ghostSpeedMs;
       if (ghost.deadTimer <= 0) {
         // Return ghost to house
         ghost.col = GHOST_START[ghost.releaseIndex].col;
@@ -392,7 +402,7 @@
       map[nr][nc] = 0;
       score += SCORE_PER_POWER * scoreMultiplier;
       totalDots--;
-      scaredUntil = performance.now() + SCARED_DURATION;
+      scaredUntil = performance.now() + activeDiff.scaredDuration;
       ghostEatChain = 0;
     }
 
@@ -460,7 +470,7 @@
       if (!ghost.released) continue;
       const dx = ghost.x - player.x;
       const dy = ghost.y - player.y;
-      if (Math.sqrt(dx * dx + dy * dy) < COLLISION_DIST) {
+      if (Math.sqrt(dx * dx + dy * dy) < CELL * activeDiff.collisionDist) {
         if (now < scaredUntil) {
           // Eat ghost (200/400/800/1600 cascade)
           const pts = GHOST_EAT_BASE * Math.pow(2, ghostEatChain) * scoreMultiplier;
@@ -483,6 +493,8 @@
       state = 'gameover';
       submitScore();
       showOverlay('GAME OVER', `Final Score: ${score}`, 'PLAY AGAIN', startGame);
+      const sel = document.getElementById('difficulty-selector');
+      if (sel) sel.style.display = 'flex';
     } else {
       // Reset positions
       player.col = PLAYER_START.col;
@@ -520,7 +532,7 @@
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ score }),
+      body: JSON.stringify({ score, difficulty: currentDifficulty }),
     })
       .then(async (res) => {
         if (res.status === 401) {
@@ -835,7 +847,7 @@
     }
 
     // Ghost movement
-    if (now - lastGhostMove > GHOST_SPEED_MS) {
+    if (now - lastGhostMove > activeDiff.ghostSpeedMs) {
       ghosts.forEach(g => moveGhost(g, now));
       lastGhostMove = now;
     }
@@ -857,7 +869,7 @@
 
     // Smooth interpolation (must happen before collision check for accurate pixel positions)
     interpolate(player, PLAYER_SPEED_MS, now);
-    ghosts.forEach(g => { if (g.released && !g.dead) interpolate(g, GHOST_SPEED_MS, now); });
+    ghosts.forEach(g => { if (g.released && !g.dead) interpolate(g, activeDiff.ghostSpeedMs, now); });
 
     // Collisions (circle-based on interpolated pixel positions)
     checkCollisions(now);
@@ -936,6 +948,8 @@
 
   // -- Start ----------------------------------------------------------------------
   function startGame() {
+    const sel = document.getElementById('difficulty-selector');
+    if (sel) sel.style.display = 'none';
     initGame();
     state = 'playing';
     lastFrame = performance.now();
@@ -945,9 +959,25 @@
     requestAnimationFrame(gameLoop);
   }
 
+  // -- Difficulty selector ---------------------------------------------------------
+  function initDifficultySelector() {
+    const selector = document.getElementById('difficulty-selector');
+    if (!selector) return;
+    const buttons = selector.querySelectorAll('[data-difficulty]');
+    buttons.forEach(btn => {
+      if (btn.dataset.difficulty === currentDifficulty) btn.classList.add('diff-active');
+      btn.addEventListener('click', () => {
+        setDifficulty(btn.dataset.difficulty);
+        buttons.forEach(b => b.classList.remove('diff-active'));
+        btn.classList.add('diff-active');
+      });
+    });
+  }
+
   window.addEventListener('load', () => {
     setupCanvas();
     updateHUD();
+    initDifficultySelector();
 
     document.getElementById('start-btn').addEventListener('click', () => {
       startGame();

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -90,6 +90,14 @@
     }
     #item-legend span { color: #fff; }
 
+    #difficulty-selector { display: flex; gap: 8px; justify-content: center; margin-top: 4px; }
+    .diff-btn { font-family: var(--font-pixel); font-size: 0.45rem; padding: 6px 14px; border: 2px solid #555; background: transparent; color: #888; cursor: pointer; letter-spacing: 0.08em; text-transform: uppercase; transition: all 0.15s; }
+    .diff-btn:hover { border-color: #aaa; color: #ccc; }
+    .diff-btn.diff-active { border-color: currentColor; text-shadow: 0 0 6px currentColor; box-shadow: 0 0 8px currentColor; }
+    .diff-btn[data-difficulty="easy"].diff-active { color: #39ff14; border-color: #39ff14; }
+    .diff-btn[data-difficulty="normal"].diff-active { color: #ffff00; border-color: #ffff00; }
+    .diff-btn[data-difficulty="hard"].diff-active { color: #ff3333; border-color: #ff3333; }
+
     /* Leaderboard panel */
     .game-leaderboard {
       background: var(--surface);
@@ -161,6 +169,11 @@
             <div>&#11088; Score Bomb 2x 10s</div>
             <div>&#127744; Warp Berry (teleport)</div>
           </div>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -228,7 +241,14 @@
           const scoreSpan = document.createElement('span');
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
-          li.append(rankSpan, nameSpan, scoreSpan);
+          li.append(rankSpan, nameSpan);
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const tag = document.createElement('span');
+            tag.textContent = s.difficulty === 'easy' ? 'E' : 'H';
+            tag.style.cssText = 'font-size:0.65rem;margin-right:4px;color:' + (s.difficulty === 'easy' ? '#39ff14' : '#ff3333');
+            li.appendChild(tag);
+          }
+          li.appendChild(scoreSpan);
           list.appendChild(li);
         }
       } catch (err) {

--- a/public/games/pacmaze/index.html
+++ b/public/games/pacmaze/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Pac-Maze Rush — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
@@ -21,6 +21,8 @@
       align-items: center;
       max-width: 100%;
       overflow-x: clip;
+      user-select: none;
+      -webkit-user-select: none;
     }
     .game-main h1 {
       color: #FFD700;
@@ -49,6 +51,8 @@
       box-shadow: 0 0 20px #1a1aff88;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;

--- a/public/games/pong/game.js
+++ b/public/games/pong/game.js
@@ -55,15 +55,7 @@ const gameOverInfo = document.getElementById('game-over-info');
 const restartBtn = document.getElementById('restart-btn');
 
 // ── Difficulty selector ─────────────────────────────────────────────────────
-let selectedDifficulty = 'normal';
-const diffBtns = document.querySelectorAll('.diff-btn');
-diffBtns.forEach(btn => {
-  btn.addEventListener('click', () => {
-    diffBtns.forEach(b => b.classList.remove('active'));
-    btn.classList.add('active');
-    selectedDifficulty = btn.dataset.diff;
-  });
-});
+let selectedDifficulty = localStorage.getItem('pong-difficulty') || 'normal';
 
 // ── Game state ──────────────────────────────────────────────────────────────
 let running = false;
@@ -127,6 +119,10 @@ function spawnParticle(x, y) {
 
 // ── Start game ──────────────────────────────────────────────────────────────
 function startGame() {
+  // Hide difficulty selector during gameplay
+  const diffSelector = document.getElementById('difficulty-selector');
+  if (diffSelector) diffSelector.style.display = 'none';
+
   playerScore = 0;
   cpuScore = 0;
   totalRallies = 0;
@@ -275,7 +271,7 @@ async function endMatch(playerWon) {
   if (!scoreSubmitted) {
     scoreSubmitted = true;
     try {
-      await api.post('/api/scores/pong', { score: totalRallies });
+      await api.post('/api/scores/pong', { score: totalRallies, difficulty: selectedDifficulty });
     } catch (err) {
       console.error('Score submission failed:', err);
     }
@@ -427,4 +423,24 @@ startBtn.addEventListener('click', startGame);
 restartBtn.addEventListener('click', () => {
   gameOverOverlay.style.display = 'none';
   overlay.style.display = 'flex';
+  // Re-show difficulty selector
+  const diffSelector = document.getElementById('difficulty-selector');
+  if (diffSelector) diffSelector.style.display = 'flex';
 });
+
+// ── Difficulty selector init ───────────────────────────────────────────────
+function initDifficultySelector() {
+  const selector = document.getElementById('difficulty-selector');
+  if (!selector) return;
+  const buttons = selector.querySelectorAll('[data-difficulty]');
+  buttons.forEach(btn => {
+    if (btn.dataset.difficulty === selectedDifficulty) btn.classList.add('diff-active');
+    btn.addEventListener('click', () => {
+      selectedDifficulty = btn.dataset.difficulty;
+      localStorage.setItem('pong-difficulty', selectedDifficulty);
+      buttons.forEach(b => b.classList.remove('diff-active'));
+      btn.classList.add('diff-active');
+    });
+  });
+}
+initDifficultySelector();

--- a/public/games/pong/game.js
+++ b/public/games/pong/game.js
@@ -264,6 +264,7 @@ function checkScore() {
 
 // ── End match ───────────────────────────────────────────────────────────────
 async function endMatch(playerWon) {
+  if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
   running = false;
   gameOverTitle.textContent = playerWon ? 'YOU WIN!' : 'YOU LOSE';
   gameOverTitle.style.color = playerWon ? '#0f0' : '#f44';
@@ -400,6 +401,26 @@ function draw() {
   ctx.fillRect(CANVAS_W - PADDLE_MARGIN - PADDLE_W, cpuY, PADDLE_W, PADDLE_H);
   ctx.shadowBlur = 0;
 }
+
+// Swipe detection for paddle movement
+(function() {
+  let touchStartY = 0;
+  let touchStartTime = 0;
+  canvas.addEventListener('touchstart', function(e) {
+    touchStartY = e.touches[0].clientY;
+    touchStartTime = Date.now();
+  }, { passive: true });
+  canvas.addEventListener('touchend', function(e) {
+    const dy = e.changedTouches[0].clientY - touchStartY;
+    if (Date.now() - touchStartTime > 400) return;
+    if (Math.abs(dy) < 30) return;
+    const key = dy > 0 ? 'ArrowDown' : 'ArrowUp';
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: key, bubbles: true }));
+    setTimeout(function() {
+      document.dispatchEvent(new KeyboardEvent('keyup', { key: key, bubbles: true }));
+    }, 50);
+  }, { passive: true });
+})();
 
 // ── Event listeners ─────────────────────────────────────────────────────────
 startBtn.addEventListener('click', startGame);

--- a/public/games/pong/index.html
+++ b/public/games/pong/index.html
@@ -94,13 +94,13 @@
       letter-spacing: 0.1em;
     }
     #overlay button:hover { background: rgba(255,238,0,0.1); }
-    #overlay .difficulty-selector {
+    /* Difficulty selector */
+    #difficulty-selector {
       display: flex;
-      gap: 0.6rem;
-      flex-wrap: wrap;
+      gap: 8px;
       justify-content: center;
     }
-    #overlay .diff-btn {
+    .diff-btn {
       background: transparent;
       border: 2px solid #555;
       color: #888;
@@ -111,13 +111,27 @@
       letter-spacing: 0.05em;
       transition: all 0.15s;
     }
-    #overlay .diff-btn.active {
-      border-color: #ffee00;
-      color: #ffee00;
-      text-shadow: 0 0 6px #ffee00;
-      box-shadow: 0 0 8px rgba(255,238,0,0.3);
+    .diff-btn:hover {
+      border-color: #aaa;
+      color: #ccc;
     }
-    #overlay .diff-btn:hover { border-color: #ffee00; color: #ffee00; }
+    .diff-btn.diff-active {
+      border-color: currentColor;
+      text-shadow: 0 0 6px currentColor;
+      box-shadow: 0 0 8px currentColor;
+    }
+    .diff-btn[data-difficulty="easy"].diff-active {
+      color: #39ff14;
+      border-color: #39ff14;
+    }
+    .diff-btn[data-difficulty="normal"].diff-active {
+      color: #ffff00;
+      border-color: #ffff00;
+    }
+    .diff-btn[data-difficulty="hard"].diff-active {
+      color: #ff3333;
+      border-color: #ff3333;
+    }
     #game-over-overlay {
       position: absolute;
       inset: 0;
@@ -184,6 +198,17 @@
     .lb-rank { color: var(--neon-cyan); min-width: 28px; }
     .lb-name { flex: 1; margin: 0 8px; }
     .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-diff {
+      font-family: var(--font-pixel);
+      font-size: 0.35rem;
+      margin-left: 6px;
+      padding: 1px 4px;
+      border-radius: 2px;
+      text-transform: uppercase;
+    }
+    .lb-diff-easy { color: #39ff14; }
+    .lb-diff-normal { color: #ffff00; }
+    .lb-diff-hard { color: #ff3333; }
     .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
 
     @media (max-width: 900px) {
@@ -249,10 +274,10 @@
             Up/Down or W/S — Move paddle<br>
             First to 10 wins. Rally count = your score.
           </p>
-          <div class="difficulty-selector">
-            <button class="diff-btn" data-diff="easy">EASY</button>
-            <button class="diff-btn active" data-diff="normal">NORMAL</button>
-            <button class="diff-btn" data-diff="hard">HARD</button>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
           </div>
           <button id="start-btn">START GAME</button>
         </div>
@@ -330,6 +355,15 @@
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
           li.append(rankSpan, nameSpan, scoreSpan);
+
+          // Show difficulty tag
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const diffSpan = document.createElement('span');
+            diffSpan.className = 'lb-diff lb-diff-' + s.difficulty;
+            diffSpan.textContent = s.difficulty === 'easy' ? 'E' : 'H';
+            li.appendChild(diffSpan);
+          }
+
           list.appendChild(li);
         }
       } catch (err) {

--- a/public/games/pong/index.html
+++ b/public/games/pong/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>Photon Paddle — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>
@@ -19,6 +19,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow: hidden;
     }
@@ -49,6 +50,8 @@
       box-shadow: 0 0 20px #ffee00, 0 0 40px #aa9900;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;
@@ -261,8 +264,8 @@
       </div>
       <div class="touch-controls" id="touch-controls">
         <div class="touch-controls-row">
-          <button class="dpad-btn" data-key="ArrowUp" style="width:64px;height:64px;font-size:1.6rem;">&#9650;</button>
-          <button class="dpad-btn" data-key="ArrowDown" style="width:64px;height:64px;font-size:1.6rem;">&#9660;</button>
+          <button class="dpad-btn" data-key="ArrowUp" style="width:72px;height:72px;font-size:1.8rem;">&#9650;</button>
+          <button class="dpad-btn" data-key="ArrowDown" style="width:72px;height:72px;font-size:1.8rem;">&#9660;</button>
         </div>
         <div class="touch-hint">TAP TO MOVE PADDLE</div>
       </div>

--- a/public/games/snake/game.js
+++ b/public/games/snake/game.js
@@ -407,19 +407,24 @@ class NeonGrowth {
     ov.appendChild(h2);
     ov.appendChild(p);
 
-    // Show difficulty selector on game over
-    const ds = typeof document !== 'undefined' && document.getElementById ? document.getElementById('difficulty-selector') : null;
-    if (ds) {
-      const clone = ds.cloneNode(true);
-      clone.style.display = 'flex';
-      clone.querySelectorAll('.diff-btn').forEach(b => {
-        b.classList.toggle('diff-active', b.dataset.difficulty === currentDifficulty);
+    // Re-add difficulty selector (guarded for Node.js test environment)
+    if (typeof document !== 'undefined' && document.getElementById) {
+      const diffDiv = document.createElement('div');
+      diffDiv.id = 'difficulty-selector';
+      ['easy','normal','hard'].forEach(d => {
+        const b = document.createElement('button');
+        b.className = 'diff-btn' + (d === currentDifficulty ? ' diff-active' : '');
+        b.dataset = b.dataset || {};
+        b.dataset.difficulty = d;
+        b.textContent = d.charAt(0).toUpperCase() + d.slice(1);
         b.addEventListener('click', () => {
-          setDifficulty(b.dataset.difficulty);
-          clone.querySelectorAll('.diff-btn').forEach(x => x.classList.toggle('diff-active', x.dataset.difficulty === currentDifficulty));
+          setDifficulty(d);
+          diffDiv.querySelectorAll('.diff-btn').forEach(x => x.classList.remove('diff-active'));
+          b.classList.add('diff-active');
         });
+        diffDiv.appendChild(b);
       });
-      ov.appendChild(clone);
+      ov.appendChild(diffDiv);
     }
 
     ov.appendChild(btn);

--- a/public/games/snake/game.js
+++ b/public/games/snake/game.js
@@ -57,6 +57,15 @@ const MAX_FOOD_ON_SCREEN = 2;
 // Base tick interval (ms between moves)
 const BASE_INTERVAL = 150;
 
+const DIFFICULTY_CONFIG = {
+  easy:   { label: 'EASY',   baseInterval: 200, trailSolidMs: 4000, wallFreq: 15 },
+  normal: { label: 'NORMAL', baseInterval: 150, trailSolidMs: 6000, wallFreq: 10 },
+  hard:   { label: 'HARD',   baseInterval: 120, trailSolidMs: 8000, wallFreq: 7 },
+};
+let currentDifficulty = localStorage.getItem('snake-difficulty') || 'normal';
+let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('snake-difficulty', d); }
+
 class NeonGrowth {
   constructor(canvas, overlay, scoreEl, highScoreEl, segmentsEl) {
     this.canvas = canvas;
@@ -203,6 +212,8 @@ class NeonGrowth {
   // ── Main game loop ─────────────────────────────────────────────────────
 
   start() {
+    const ds = typeof document !== 'undefined' && document.getElementById ? document.getElementById('difficulty-selector') : null;
+    if (ds) ds.style.display = 'none';
     this._reset();
     this.running = true;
     this.gameOverFlag = false;
@@ -212,8 +223,8 @@ class NeonGrowth {
   }
 
   _currentInterval() {
-    if (performance.now() < this.speedBoostExpiry) return BASE_INTERVAL / 1.3;
-    return BASE_INTERVAL;
+    if (performance.now() < this.speedBoostExpiry) return activeDiff.baseInterval / 1.3;
+    return activeDiff.baseInterval;
   }
 
   _loop(ts) {
@@ -267,10 +278,10 @@ class NeonGrowth {
       return;
     }
 
-    // Collision: solid trail (born within TRAIL_SOLID_MS)
+    // Collision: solid trail (born within activeDiff.trailSolidMs)
     const now = performance.now();
     const solidTrailHit = this.trail.some(
-      (t) => t.x === nx && t.y === ny && now - t.born < TRAIL_SOLID_MS
+      (t) => t.x === nx && t.y === ny && now - t.born < activeDiff.trailSolidMs
     );
     if (solidTrailHit) {
       this._endGame();
@@ -312,8 +323,9 @@ class NeonGrowth {
       this.segmentCount = this.snake.length + this._growQueue;
       this._updateHUD();
 
-      // Wall generation every 10 segments
-      const threshold = Math.floor(this.segmentCount / 10) * 10;
+      // Wall generation every N segments (based on difficulty)
+      const wf = activeDiff.wallFreq;
+      const threshold = Math.floor(this.segmentCount / wf) * wf;
       if (threshold > 0 && threshold > this._lastWallThreshold) {
         this._lastWallThreshold = threshold;
         this._spawnWalls();
@@ -339,7 +351,7 @@ class NeonGrowth {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ score: this.score }),
+      body: JSON.stringify({ score: this.score, difficulty: currentDifficulty }),
     })
       .then(async (res) => {
         if (res.status === 401) {
@@ -394,6 +406,22 @@ class NeonGrowth {
 
     ov.appendChild(h2);
     ov.appendChild(p);
+
+    // Show difficulty selector on game over
+    const ds = typeof document !== 'undefined' && document.getElementById ? document.getElementById('difficulty-selector') : null;
+    if (ds) {
+      const clone = ds.cloneNode(true);
+      clone.style.display = 'flex';
+      clone.querySelectorAll('.diff-btn').forEach(b => {
+        b.classList.toggle('diff-active', b.dataset.difficulty === currentDifficulty);
+        b.addEventListener('click', () => {
+          setDifficulty(b.dataset.difficulty);
+          clone.querySelectorAll('.diff-btn').forEach(x => x.classList.toggle('diff-active', x.dataset.difficulty === currentDifficulty));
+        });
+      });
+      ov.appendChild(clone);
+    }
+
     ov.appendChild(btn);
     ov.style.display = 'flex';
   }
@@ -438,7 +466,7 @@ class NeonGrowth {
       const age = now - seg.born;
       if (age >= TRAIL_FADE_MS) continue;
       const alpha = 1 - age / TRAIL_FADE_MS;
-      const solid = age < TRAIL_SOLID_MS;
+      const solid = age < activeDiff.trailSolidMs;
 
       ctx.save();
       ctx.globalAlpha = alpha * 0.6;
@@ -571,3 +599,16 @@ document.getElementById('start-btn').addEventListener('click', () => {
   overlay.style.display = 'none';
   game.start();
 });
+
+function initDifficultySelector() {
+  const ds = typeof document !== 'undefined' && document.getElementById ? document.getElementById('difficulty-selector') : null;
+  if (!ds) return;
+  ds.querySelectorAll('.diff-btn').forEach(btn => {
+    btn.classList.toggle('diff-active', btn.dataset.difficulty === currentDifficulty);
+    btn.addEventListener('click', () => {
+      setDifficulty(btn.dataset.difficulty);
+      ds.querySelectorAll('.diff-btn').forEach(b => b.classList.toggle('diff-active', b.dataset.difficulty === currentDifficulty));
+    });
+  });
+}
+initDifficultySelector();

--- a/public/games/snake/game.js
+++ b/public/games/snake/game.js
@@ -324,6 +324,7 @@ class NeonGrowth {
   }
 
   _endGame() {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
     this.running = false;
     if (cancelAnimationFrame) cancelAnimationFrame(this._rafId);
 

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Neon Growth — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
@@ -20,6 +20,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow-x: clip;
     }
@@ -50,6 +51,8 @@
       box-shadow: 0 0 20px #0ff, 0 0 40px #0080ff;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;

--- a/public/games/snake/index.html
+++ b/public/games/snake/index.html
@@ -135,6 +135,14 @@
     .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
     .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
 
+    #difficulty-selector { display: flex; gap: 8px; justify-content: center; margin-top: 4px; }
+    .diff-btn { font-family: var(--font-pixel); font-size: 0.45rem; padding: 6px 14px; border: 2px solid #555; background: transparent; color: #888; cursor: pointer; letter-spacing: 0.08em; text-transform: uppercase; transition: all 0.15s; }
+    .diff-btn:hover { border-color: #aaa; color: #ccc; }
+    .diff-btn.diff-active { border-color: currentColor; text-shadow: 0 0 6px currentColor; box-shadow: 0 0 8px currentColor; }
+    .diff-btn[data-difficulty="easy"].diff-active { color: #39ff14; border-color: #39ff14; }
+    .diff-btn[data-difficulty="normal"].diff-active { color: #ffff00; border-color: #ffff00; }
+    .diff-btn[data-difficulty="hard"].diff-active { color: #ff3333; border-color: #ff3333; }
+
     @media (max-width: 900px) {
       .game-layout { flex-direction: column; align-items: center; }
       .game-leaderboard { max-width: 100%; min-width: 280px; }
@@ -171,6 +179,11 @@
         <div id="overlay">
           <h2>NEON GROWTH</h2>
           <p>Arrow keys, WASD, or swipe to move</p>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -240,6 +253,12 @@
           const nameSpan = document.createElement('span');
           nameSpan.className = 'lb-name';
           nameSpan.textContent = isSelf ? s.username + ' (YOU)' : s.username;
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const diffTag = document.createElement('span');
+            diffTag.style.cssText = 'font-size:0.6rem;opacity:0.6;margin-left:2px;';
+            diffTag.textContent = s.difficulty.charAt(0).toUpperCase();
+            nameSpan.appendChild(diffTag);
+          }
           const scoreSpan = document.createElement('span');
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
@@ -264,6 +283,6 @@
       loadMiniLeaderboard();
     });
   </script>
-  <script src="game.js?v=2" type="module"></script>
+  <script src="game.js?v=3" type="module"></script>
 </body>
 </html>

--- a/public/games/space-invaders/game.js
+++ b/public/games/space-invaders/game.js
@@ -635,6 +635,7 @@ class GameEngine {
   }
 
   _playerHit(damage) {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(100);
     if (this.invincibleTimer > 0) return;
 
     if (this.shield > 0) {

--- a/public/games/space-invaders/game.js
+++ b/public/games/space-invaders/game.js
@@ -37,6 +37,16 @@ const POWERUP_COLORS = {
   shield: '#fff',
 };
 
+// ── Difficulty settings ─────────────────────────────────────────────────────
+const DIFFICULTY_CONFIG = {
+  easy:   { label: 'EASY',   enemySpeedMult: 0.7, maxLives: 4, shieldRegen: 8, waveSpeedMult: 0.7 },
+  normal: { label: 'NORMAL', enemySpeedMult: 1.0, maxLives: 3, shieldRegen: 5, waveSpeedMult: 1.0 },
+  hard:   { label: 'HARD',   enemySpeedMult: 1.3, maxLives: 2, shieldRegen: 3, waveSpeedMult: 1.3 },
+};
+let currentDifficulty = localStorage.getItem('spaceinvaders-difficulty') || 'normal';
+let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('spaceinvaders-difficulty', d); }
+
 // ── Game constants ──────────────────────────────────────────────────────────
 const PLAYER_W = 30;
 const PLAYER_H = 20;
@@ -240,7 +250,7 @@ class GameEngine {
     // Player state
     this.playerX = this.width / 2;
     this.playerY = this.height - 40;
-    this.lives = MAX_LIVES;
+    this.lives = activeDiff.maxLives;
     this.shield = MAX_SHIELD;
     this.score = 0;
     this.wave = 0;
@@ -274,7 +284,7 @@ class GameEngine {
   _startNextWave() {
     this.wave++;
     const isBossWave = this.wave % BOSS_WAVE_INTERVAL === 0;
-    const waveSpeed = 1 + this.wave * 0.05;
+    const waveSpeed = (1 + this.wave * 0.05) * activeDiff.waveSpeedMult;
     const enemyCount = Math.min(5 + this.wave * 2, 30);
 
     if (isBossWave) {
@@ -308,7 +318,7 @@ class GameEngine {
         const typeRoll = Math.random();
         const type = typeRoll < 0.5 ? 'scout' : typeRoll < 0.8 ? 'drone' : 'heavy';
         const def = ENEMY_TYPES[type];
-        const angSpeed = (0.5 + Math.random() * 0.8) * waveSpeed * def.speed;
+        const angSpeed = (0.5 + Math.random() * 0.8) * waveSpeed * def.speed * activeDiff.enemySpeedMult;
 
         this.enemies.push(new OrbitalEnemy({
           type,
@@ -559,7 +569,7 @@ class GameEngine {
 
   _regenerateShield(dt) {
     if (this.shield < MAX_SHIELD) {
-      this.shield = Math.min(MAX_SHIELD, this.shield + SHIELD_REGEN_PER_SEC * dt);
+      this.shield = Math.min(MAX_SHIELD, this.shield + activeDiff.shieldRegen * dt);
     }
   }
 
@@ -863,6 +873,8 @@ class AsteroidDefenseRenderer {
   }
 
   start() {
+    const ds = document.getElementById('difficulty-selector');
+    if (ds) ds.style.display = 'none';
     this.engine.reset();
     this._running = true;
     this._lastTime = performance.now();
@@ -904,7 +916,7 @@ class AsteroidDefenseRenderer {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       credentials: 'include',
-      body: JSON.stringify({ score: state.score }),
+      body: JSON.stringify({ score: state.score, difficulty: currentDifficulty }),
     })
       .then(async (res) => {
         if (res.status === 401) {
@@ -950,6 +962,22 @@ class AsteroidDefenseRenderer {
     const p = document.createElement('p');
     p.textContent = `Score: ${state.score}  |  Wave: ${state.wave}  |  Best: ${this.highScore}`;
 
+    // Re-create difficulty selector in overlay
+    const diffDiv = document.createElement('div');
+    diffDiv.id = 'difficulty-selector';
+    ['easy', 'normal', 'hard'].forEach(d => {
+      const b = document.createElement('button');
+      b.className = 'diff-btn' + (d === currentDifficulty ? ' diff-active' : '');
+      b.dataset.difficulty = d;
+      b.textContent = d.charAt(0).toUpperCase() + d.slice(1);
+      b.addEventListener('click', () => {
+        setDifficulty(d);
+        diffDiv.querySelectorAll('.diff-btn').forEach(x => x.classList.remove('diff-active'));
+        b.classList.add('diff-active');
+      });
+      diffDiv.appendChild(b);
+    });
+
     const btn = document.createElement('button');
     btn.textContent = 'PLAY AGAIN';
     btn.addEventListener('click', () => {
@@ -958,6 +986,7 @@ class AsteroidDefenseRenderer {
 
     ov.appendChild(h2);
     ov.appendChild(p);
+    ov.appendChild(diffDiv);
     ov.appendChild(btn);
     ov.style.display = 'flex';
   }
@@ -1230,6 +1259,27 @@ const renderer = new AsteroidDefenseRenderer(canvas, overlay, hud);
 startBtn.addEventListener('click', () => {
   renderer.start();
 });
+
+// ── Difficulty selector ────────────────────────────────────────────────────
+function initDifficultySelector() {
+  const selector = document.getElementById('difficulty-selector');
+  if (!selector) return;
+
+  const buttons = selector.querySelectorAll('[data-difficulty]');
+  buttons.forEach(btn => {
+    if (btn.dataset.difficulty === currentDifficulty) {
+      btn.classList.add('diff-active');
+    }
+
+    btn.addEventListener('click', () => {
+      setDifficulty(btn.dataset.difficulty);
+      buttons.forEach(b => b.classList.remove('diff-active'));
+      btn.classList.add('diff-active');
+    });
+  });
+}
+
+initDifficultySelector();
 
 // Export for testing (Node.js environment detection)
 if (typeof module !== 'undefined' && module.exports) {

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <title>Asteroid Defense Surge — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
@@ -20,6 +20,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow-x: clip;
     }
@@ -50,6 +51,8 @@
       box-shadow: 0 0 20px #f0f, 0 0 40px #8000ff;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;
@@ -220,9 +223,9 @@
       </div>
       <div class="touch-controls" id="touch-controls">
         <div class="touch-controls-row">
-          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:72px;height:72px;font-size:1.8rem;">&#9664;</button>
           <button class="touch-btn-fire" id="fire-btn">FIRE</button>
-          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:72px;height:72px;font-size:1.8rem;">&#9654;</button>
         </div>
         <div class="touch-hint">DRAG TO MOVE &bull; TAP TO FIRE</div>
       </div>

--- a/public/games/space-invaders/index.html
+++ b/public/games/space-invaders/index.html
@@ -95,6 +95,46 @@
       letter-spacing: 0.1em;
     }
     #overlay button:hover { background: rgba(255,0,255,0.1); }
+    /* Difficulty selector */
+    #difficulty-selector {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+      margin-top: 4px;
+    }
+    .diff-btn {
+      font-family: var(--font-pixel);
+      font-size: 0.45rem;
+      padding: 6px 14px;
+      background: transparent;
+      border: 2px solid #555;
+      color: #888;
+      cursor: pointer;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      transition: all 0.15s;
+    }
+    .diff-btn:hover {
+      border-color: #aaa;
+      color: #ccc;
+    }
+    .diff-btn.diff-active {
+      border-color: currentColor;
+      text-shadow: 0 0 6px currentColor;
+      box-shadow: 0 0 8px currentColor;
+    }
+    .diff-btn[data-difficulty="easy"].diff-active {
+      color: #39ff14;
+      border-color: #39ff14;
+    }
+    .diff-btn[data-difficulty="normal"].diff-active {
+      color: #ffff00;
+      border-color: #ffff00;
+    }
+    .diff-btn[data-difficulty="hard"].diff-active {
+      color: #ff3333;
+      border-color: #ff3333;
+    }
     #legend {
       display: flex;
       gap: 1.2rem;
@@ -138,6 +178,17 @@
     .lb-rank { color: var(--neon-cyan); min-width: 28px; }
     .lb-name { flex: 1; margin: 0 8px; }
     .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    .lb-diff {
+      font-family: var(--font-pixel);
+      font-size: 0.35rem;
+      margin-left: 6px;
+      padding: 1px 4px;
+      border-radius: 2px;
+      text-transform: uppercase;
+    }
+    .lb-diff-easy { color: #39ff14; }
+    .lb-diff-normal { color: #ffff00; }
+    .lb-diff-hard { color: #ff3333; }
     .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
 
     @media (max-width: 900px) {
@@ -166,6 +217,10 @@
       #overlay button {
         font-size: 0.85rem;
         padding: 0.35rem 1.2rem;
+      }
+      .diff-btn {
+        font-size: 0.38rem;
+        padding: 5px 10px;
       }
       #legend {
         font-size: 0.6rem;
@@ -210,6 +265,11 @@
             Space / Tap — Shoot (hold for Charge/Laser)<br>
             Destroy orbiters to collect weapon upgrades
           </p>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -307,6 +367,15 @@
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
           li.append(rankSpan, nameSpan, scoreSpan);
+
+          // Show difficulty tag
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const diffSpan = document.createElement('span');
+            diffSpan.className = 'lb-diff lb-diff-' + s.difficulty;
+            diffSpan.textContent = s.difficulty === 'easy' ? 'E' : 'H';
+            li.appendChild(diffSpan);
+          }
+
           list.appendChild(li);
         }
       } catch (err) {

--- a/public/games/tetris/game.js
+++ b/public/games/tetris/game.js
@@ -335,6 +335,7 @@
   function lockAndAdvance() {
     lockPiece();
     const cleared = clearLines();
+    if (cleared > 0 && typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(cleared > 1 ? 80 : 40);
     if (cleared > 0) {
       score += LINE_SCORES[cleared] * level;
       lines += cleared;
@@ -512,6 +513,33 @@
     drawSidePanels();
   }
 
+  // Swipe detection for piece movement
+  (function() {
+    let touchStartX = 0, touchStartY = 0, touchStartTime = 0;
+    canvas.addEventListener('touchstart', function(e) {
+      touchStartX = e.touches[0].clientX;
+      touchStartY = e.touches[0].clientY;
+      touchStartTime = Date.now();
+    }, { passive: true });
+    canvas.addEventListener('touchend', function(e) {
+      const dx = e.changedTouches[0].clientX - touchStartX;
+      const dy = e.changedTouches[0].clientY - touchStartY;
+      if (Date.now() - touchStartTime > 400) return;
+      const absDx = Math.abs(dx), absDy = Math.abs(dy);
+      if (absDx < 30 && absDy < 30) return;
+      var key;
+      if (absDx > absDy) {
+        key = dx > 0 ? 'ArrowRight' : 'ArrowLeft';
+      } else {
+        key = dy > 0 ? 'ArrowDown' : 'ArrowUp';
+      }
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: key, bubbles: true }));
+      setTimeout(function() {
+        document.dispatchEvent(new KeyboardEvent('keyup', { key: key, bubbles: true }));
+      }, 50);
+    }, { passive: true });
+  })();
+
   // ── Game loop ─────────────────────────────────────────────────────────────
   function gameLoop(timestamp) {
     if (!running) return;
@@ -531,6 +559,7 @@
 
   // ── Game over ─────────────────────────────────────────────────────────────
   async function endGame() {
+    if (typeof navigator !== 'undefined' && navigator.vibrate) navigator.vibrate(150);
     gameOver = true;
     running = false;
 

--- a/public/games/tetris/game.js
+++ b/public/games/tetris/game.js
@@ -124,6 +124,16 @@
   // ── Scoring ───────────────────────────────────────────────────────────────
   const LINE_SCORES = [0, 100, 300, 500, 800];
 
+  // ── Difficulty ────────────────────────────────────────────────────────────
+  const DIFFICULTY_CONFIG = {
+    easy:   { label: 'EASY',   baseDropInterval: 1200, levelSpeedDecrease: 60, minDropInterval: 100 },
+    normal: { label: 'NORMAL', baseDropInterval: 1000, levelSpeedDecrease: 80, minDropInterval: 50 },
+    hard:   { label: 'HARD',   baseDropInterval: 800,  levelSpeedDecrease: 100, minDropInterval: 30 },
+  };
+  let currentDifficulty = localStorage.getItem('tetris-difficulty') || 'normal';
+  let activeDiff = DIFFICULTY_CONFIG[currentDifficulty];
+  function setDifficulty(d) { currentDifficulty = d; activeDiff = DIFFICULTY_CONFIG[d]; localStorage.setItem('tetris-difficulty', d); }
+
   // ── Game state ────────────────────────────────────────────────────────────
   let board = [];           // ROWS x COLS, each cell null or color string
   let currentPiece = null;  // { name, rotation, x, y }
@@ -135,7 +145,7 @@
   let lines = 0;
   let gameOver = false;
   let running = false;
-  let dropInterval = 1000;
+  let dropInterval = activeDiff.baseDropInterval;
   let dropAccumulator = 0;
   let lastTime = 0;
   let bag = [];
@@ -342,7 +352,7 @@
       const newLevel = Math.floor(lines / 10) + 1;
       if (newLevel > level) {
         level = newLevel;
-        dropInterval = Math.max(50, 1000 - (level - 1) * 80);
+        dropInterval = Math.max(activeDiff.minDropInterval, activeDiff.baseDropInterval - (level - 1) * activeDiff.levelSpeedDecrease);
       }
     }
     updateHud();
@@ -572,14 +582,25 @@
     const btn = document.createElement('button');
     btn.textContent = 'PLAY AGAIN';
     btn.addEventListener('click', startGame);
-    overlay.append(h2, p, btn);
+    // Re-add difficulty selector
+    const diffDiv = document.createElement('div');
+    diffDiv.id = 'difficulty-selector';
+    ['easy','normal','hard'].forEach(d => {
+      const b = document.createElement('button');
+      b.className = 'diff-btn' + (d === currentDifficulty ? ' diff-active' : '');
+      b.dataset.difficulty = d;
+      b.textContent = d.charAt(0).toUpperCase() + d.slice(1);
+      diffDiv.appendChild(b);
+    });
+    overlay.append(h2, p, diffDiv, btn);
     overlay.style.display = 'flex';
+    initDifficultySelector();
 
     // Submit score
     try {
       const user = await api.getUser();
       if (user) {
-        await api.post('/api/scores/tetris', { score });
+        await api.post('/api/scores/tetris', { score, difficulty: currentDifficulty });
         if (typeof loadMiniLeaderboard === 'function') loadMiniLeaderboard();
       }
     } catch (err) {
@@ -593,7 +614,7 @@
     score = 0;
     level = 1;
     lines = 0;
-    dropInterval = 1000;
+    dropInterval = activeDiff.baseDropInterval;
     dropAccumulator = 0;
     lastTime = 0;
     gameOver = false;
@@ -610,6 +631,9 @@
 
     updateHud();
     overlay.style.display = 'none';
+    // Hide difficulty selector during gameplay
+    const diffSelector = document.getElementById('difficulty-selector');
+    if (diffSelector) diffSelector.style.display = 'none';
     running = true;
     requestAnimationFrame(gameLoop);
   }
@@ -708,8 +732,28 @@
     }
   });
 
+  // ── Difficulty selector ────────────────────────────────────────────────────
+  function initDifficultySelector() {
+    const selector = document.getElementById('difficulty-selector');
+    if (!selector) return;
+
+    const buttons = selector.querySelectorAll('[data-difficulty]');
+    buttons.forEach(btn => {
+      if (btn.dataset.difficulty === currentDifficulty) {
+        btn.classList.add('diff-active');
+      }
+
+      btn.addEventListener('click', () => {
+        setDifficulty(btn.dataset.difficulty);
+        buttons.forEach(b => b.classList.remove('diff-active'));
+        btn.classList.add('diff-active');
+      });
+    });
+  }
+
   // ── Start button ──────────────────────────────────────────────────────────
   startBtn.addEventListener('click', startGame);
+  initDifficultySelector();
 
   // Initial draw
   board = createBoard();

--- a/public/games/tetris/index.html
+++ b/public/games/tetris/index.html
@@ -123,6 +123,59 @@
     .lb-rank { color: var(--neon-cyan); min-width: 28px; }
     .lb-name { flex: 1; margin: 0 8px; }
     .lb-score { color: var(--neon-green); font-family: var(--font-mono); }
+    /* Difficulty selector */
+    #difficulty-selector {
+      display: flex;
+      gap: 8px;
+      justify-content: center;
+      margin-top: 4px;
+    }
+    .diff-btn {
+      font-family: var(--font-pixel);
+      font-size: 0.45rem;
+      padding: 6px 14px;
+      border: 2px solid #555;
+      background: transparent;
+      color: #888;
+      cursor: pointer;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      transition: all 0.15s;
+    }
+    .diff-btn:hover {
+      border-color: #aaa;
+      color: #ccc;
+    }
+    .diff-btn.diff-active {
+      border-color: currentColor;
+      text-shadow: 0 0 6px currentColor;
+      box-shadow: 0 0 8px currentColor;
+    }
+    .diff-btn[data-difficulty="easy"].diff-active {
+      color: #39ff14;
+      border-color: #39ff14;
+    }
+    .diff-btn[data-difficulty="normal"].diff-active {
+      color: #ffff00;
+      border-color: #ffff00;
+    }
+    .diff-btn[data-difficulty="hard"].diff-active {
+      color: #ff3333;
+      border-color: #ff3333;
+    }
+
+    /* Difficulty tags in leaderboard */
+    .lb-diff {
+      font-family: var(--font-pixel);
+      font-size: 0.35rem;
+      margin-left: 6px;
+      padding: 1px 4px;
+      border-radius: 2px;
+      text-transform: uppercase;
+    }
+    .lb-diff-easy { color: #39ff14; }
+    .lb-diff-normal { color: #ffff00; }
+    .lb-diff-hard { color: #ff3333; }
     .lb-empty { color: #555; font-size: 0.75rem; text-align: center; padding: 12px 0; }
 
     @media (max-width: 900px) {
@@ -191,6 +244,11 @@
             Space — Hard drop<br>
             C — Hold piece
           </p>
+          <div id="difficulty-selector">
+            <button class="diff-btn" data-difficulty="easy">Easy</button>
+            <button class="diff-btn" data-difficulty="normal">Normal</button>
+            <button class="diff-btn" data-difficulty="hard">Hard</button>
+          </div>
           <button id="start-btn">START GAME</button>
         </div>
       </div>
@@ -293,6 +351,15 @@
           scoreSpan.className = 'lb-score';
           scoreSpan.textContent = s.score.toLocaleString();
           li.append(rankSpan, nameSpan, scoreSpan);
+
+          // Show difficulty tag
+          if (s.difficulty && s.difficulty !== 'normal') {
+            const diffSpan = document.createElement('span');
+            diffSpan.className = 'lb-diff lb-diff-' + s.difficulty;
+            diffSpan.textContent = s.difficulty === 'easy' ? 'E' : 'H';
+            li.appendChild(diffSpan);
+          }
+
           list.appendChild(li);
         }
       } catch (err) {

--- a/public/games/tetris/index.html
+++ b/public/games/tetris/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>Neon Stack — Retro Arcade</title>
   <link rel="stylesheet" href="/css/main.css" />
   <style>
@@ -19,6 +19,7 @@
       flex-direction: column;
       align-items: center;
       user-select: none;
+      -webkit-user-select: none;
       max-width: 100%;
       overflow: hidden;
     }
@@ -49,6 +50,8 @@
       box-shadow: 0 0 20px #ff8800, 0 0 40px #cc6600;
       max-width: 100%;
       height: auto;
+      touch-action: none;
+      -webkit-touch-callout: none;
     }
     #overlay {
       position: absolute;
@@ -193,9 +196,9 @@
       </div>
       <div class="touch-controls" id="touch-controls">
         <div class="touch-controls-row">
-          <button class="dpad-btn" data-key="ArrowLeft" style="width:64px;height:64px;font-size:1.6rem;">&#9664;</button>
-          <button class="dpad-btn" data-key="ArrowDown" style="width:64px;height:64px;font-size:1.6rem;">&#9660;</button>
-          <button class="dpad-btn" data-key="ArrowRight" style="width:64px;height:64px;font-size:1.6rem;">&#9654;</button>
+          <button class="dpad-btn" data-key="ArrowLeft" style="width:72px;height:72px;font-size:1.8rem;">&#9664;</button>
+          <button class="dpad-btn" data-key="ArrowDown" style="width:72px;height:72px;font-size:1.8rem;">&#9660;</button>
+          <button class="dpad-btn" data-key="ArrowRight" style="width:72px;height:72px;font-size:1.8rem;">&#9654;</button>
         </div>
         <div class="touch-controls-row" style="margin-top:8px;">
           <button class="touch-btn-fire" id="rotate-btn">ROTATE</button>

--- a/public/leaderboard.html
+++ b/public/leaderboard.html
@@ -37,7 +37,7 @@
     <div class="tab-content active" id="tab-overall">
       <div class="loading" id="overall-loading">LOADING...</div>
       <div class="table-wrap" id="overall-table-wrap" style="display:none;">
-        <table>
+        <table style="min-width:900px;">
           <thead>
             <tr>
               <th>Rank</th>


### PR DESCRIPTION
## Summary
- Adds Easy/Normal/Hard difficulty selector to all 7 remaining games (Hopper already had it from #81)
- Each game: DIFFICULTY_CONFIG object, localStorage persistence, selector on start overlay, score submission with difficulty field
- Leaderboard mini-panels show E/H tags for non-normal difficulties
- Games affected: Pac-Maze, Neon Growth, Asteroid Defense, Photon Paddle, Neon Stack, Brick Blitz, Void Drifter

## Difficulty tuning per game
| Game | Easy | Hard |
|------|------|------|
| Pac-Maze | Slower ghosts, longer scared, 5 lives, smaller hitbox | Faster ghosts, shorter scared, 2 lives, bigger hitbox |
| Neon Growth | Slower tick, shorter solid trail, fewer walls | Faster tick, longer solid trail, more walls |
| Asteroid Defense | Slower enemies, 4 lives, faster shield regen | Faster enemies, 2 lives, slower regen |
| Photon Paddle | Slower CPU, wider reaction zone | Faster CPU, narrow reaction zone |
| Neon Stack | Slower drop, gentler speed increase | Faster drop, aggressive speed increase |
| Brick Blitz | Slower ball, wider paddle, 5 lives | Faster ball, narrow paddle, 2 lives |
| Void Drifter | Slower asteroids, 5 lives, longer invuln | Faster asteroids, 2 lives, shorter invuln, 5 starting asteroids |

## Test plan
- [x] All 188 tests pass (`npm test`)
- [ ] Verify difficulty selector appears on each game start overlay
- [ ] Verify Easy/Normal/Hard persists across page reloads (localStorage)
- [ ] Verify score submission includes difficulty field
- [ ] Verify leaderboard shows E/H tags for non-normal scores

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)