### PR TITLE
fix: auto-fire key conflict and stuck fire state

### DIFF
--- a/public/games/asteroids/game.js
+++ b/public/games/asteroids/game.js
@@ -769,8 +769,9 @@ document.addEventListener('keydown', (e) => {
   if (e.key === ' ' || e.key === 'ArrowUp' || e.key === 'ArrowDown' || e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
     e.preventDefault();
   }
-  if (e.key === 'a' || e.key === 'A') {
+  if (e.key === 'q' || e.key === 'Q') {
     autoFireEnabled = !autoFireEnabled;
+    if (!autoFireEnabled) keys[' '] = false;
     const btn = document.getElementById('autofire-btn');
     if (btn) { btn.classList.toggle('active', autoFireEnabled); btn.textContent = autoFireEnabled ? 'AUTO*' : 'AUTO'; }
   }
@@ -803,6 +804,7 @@ const autoFireBtn = document.getElementById('autofire-btn');
 if (autoFireBtn) {
   autoFireBtn.addEventListener('click', () => {
     autoFireEnabled = !autoFireEnabled;
+    if (!autoFireEnabled) keys[' '] = false;
     autoFireBtn.classList.toggle('active', autoFireEnabled);
     autoFireBtn.textContent = autoFireEnabled ? 'AUTO*' : 'AUTO';
   });

--- a/public/games/space-invaders/game.js
+++ b/public/games/space-invaders/game.js
@@ -758,9 +758,10 @@ class AsteroidDefenseRenderer {
           e.preventDefault();
           break;
       }
-      if (e.key === 'a' || e.key === 'A') {
+      if (e.key === 'q' || e.key === 'Q') {
         if (typeof autoFireEnabled !== 'undefined') {
           autoFireEnabled = !autoFireEnabled;
+          if (!autoFireEnabled) this.engine.keys.fire = false;
           const btn = document.getElementById('autofire-btn');
           if (btn) { btn.classList.toggle('active', autoFireEnabled); btn.textContent = autoFireEnabled ? 'AUTO*' : 'AUTO'; }
         }


### PR DESCRIPTION
## Summary
- Change auto-fire toggle from 'A' to 'Q' — 'A' conflicts with left rotation (Asteroids) and left movement (Space Invaders)
- Clear fire key state when auto-fire is disabled to prevent stuck firing

## Test plan
- [x] All 188 tests pass
- [ ] Verify 'Q' toggles auto-fire without interfering with WASD
- [ ] Verify disabling auto-fire stops firing immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remapped auto-fire toggle keyboard shortcut from A to Q key in Asteroids and Space Invaders games
  * Fixed issue where firing state persisted after disabling auto-fire, ensuring firing stops immediately when toggled off

<!-- end of auto-generated comment: release notes by coderabbit.ai -->